### PR TITLE
fix(TODO-54): 디자인토큰 `text-lg`의 line-height 오타 수정 `18px => 28px`

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,7 +20,7 @@
   --text-base--line-height: 24px;
 
   --text-lg: 18px;
-  --text-lg--line-height: 18px;
+  --text-lg--line-height: 28px;
 
   --text-xl: 20px;
   --text-xl--line-height: 28px;


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-54)
  
<br/>

## 📗 작업 내용

- 디자인토큰 `text-lg`의 line-height가 "18px"로 잘 못 설정되어 있어 "28px"로 수정하였습니다.

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


