### PR TITLE
feat(TODO-74): Dropdown 공통 컴포넌트 분리 및 범용성 개선

### DIFF
--- a/src/components/atoms/dropdown/dropdown.tsx
+++ b/src/components/atoms/dropdown/dropdown.tsx
@@ -3,42 +3,37 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 
 const dropdownVariants = cva(
-  "flex w-fit flex-col gap-3 rounded-xl text-slate-700 shadow-lg z-10 bg-white",
+  "font-normal cursor-pointer m-auto rounded-lg hover:bg-gray-200",
   {
     variants: {
       size: {
-        md: "py-2 px-[21.5px]",
-        sm: "py-2 px-4",
+        sm: "text-sm py-2 px-4",
+        md: "text-lg py-2 px-[21.5px]",
       },
+    },
+    defaultVariants: {
+      size: "sm",
     },
   },
 );
 
-const textVariants = cva(
-  "font-normal cursor-pointer rounded-md p-2 hover:bg-gray-100",
-  {
-    variants: {
-      size: {
-        md: "text-lg",
-        sm: "text-sm",
-      },
-    },
-  },
-);
-
-interface DropdownProps
-  extends Required<VariantProps<typeof dropdownVariants>> {
-  className?: string;
+interface DropdownProps extends VariantProps<typeof dropdownVariants> {
   items: { label: string; onClick: () => void }[];
+  className?: string;
 }
 
-function Dropdown({ size, className, items }: DropdownProps) {
+function Dropdown({ size, items, className }: DropdownProps) {
   return (
-    <div className={cn(dropdownVariants({ size }), className)}>
+    <div
+      className={cn(
+        "flex w-fit flex-col rounded-xl bg-white text-slate-700 shadow-lg",
+        className,
+      )}
+    >
       {items.map((item, idx) => (
         <div
           key={idx}
-          className={cn(textVariants({ size }))}
+          className={cn(dropdownVariants({ size }))}
           onClick={item.onClick}
         >
           {item.label}

--- a/src/components/atoms/dropdown/dropdown.tsx
+++ b/src/components/atoms/dropdown/dropdown.tsx
@@ -1,9 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
-import Link from "next/link";
 
 import { cn } from "@/utils/cn";
-
-const dropdownMenus = ["수정하기", "삭제하기"];
 
 const dropdownVariants = cva(
   "flex w-fit flex-col gap-3 rounded-xl text-slate-700 shadow-lg z-10 bg-white",
@@ -17,28 +14,35 @@ const dropdownVariants = cva(
   },
 );
 
-const textVariants = cva("font-normal", {
-  variants: {
-    size: {
-      md: "text-lg",
-      sm: "text-sm",
+const textVariants = cva(
+  "font-normal cursor-pointer rounded-md p-2 hover:bg-gray-100",
+  {
+    variants: {
+      size: {
+        md: "text-lg",
+        sm: "text-sm",
+      },
     },
   },
-});
+);
 
-// variants 속성들을 props로 필수로 받도록 함
 interface DropdownProps
   extends Required<VariantProps<typeof dropdownVariants>> {
   className?: string;
+  items: { label: string; onClick: () => void }[];
 }
 
-function Dropdown({ size, className }: DropdownProps) {
+function Dropdown({ size, className, items }: DropdownProps) {
   return (
     <div className={cn(dropdownVariants({ size }), className)}>
-      {dropdownMenus.map((menu, idx) => (
-        <Link href={"#"} className={cn(textVariants({ size }))} key={idx}>
-          {menu}
-        </Link>
+      {items.map((item, idx) => (
+        <div
+          key={idx}
+          className={cn(textVariants({ size }))}
+          onClick={item.onClick}
+        >
+          {item.label}
+        </div>
       ))}
     </div>
   );

--- a/src/components/atoms/dropdown/dropdown.tsx
+++ b/src/components/atoms/dropdown/dropdown.tsx
@@ -22,7 +22,7 @@ interface DropdownProps extends VariantProps<typeof dropdownVariants> {
   className?: string;
 }
 
-function Dropdown({ size, items, className }: DropdownProps) {
+export default function Dropdown({ size, items, className }: DropdownProps) {
   return (
     <div
       className={cn(
@@ -42,5 +42,3 @@ function Dropdown({ size, items, className }: DropdownProps) {
     </div>
   );
 }
-
-export default Dropdown;

--- a/views/notes/dropdown.tsx
+++ b/views/notes/dropdown.tsx
@@ -1,0 +1,47 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import Link from "next/link";
+
+import { cn } from "@/utils/cn";
+
+const dropdownMenus = ["수정하기", "삭제하기"];
+
+const dropdownVariants = cva(
+  "flex w-fit flex-col gap-3 rounded-xl text-slate-700 shadow-lg z-10 bg-white",
+  {
+    variants: {
+      size: {
+        md: "py-2 px-[21.5px]",
+        sm: "py-2 px-4",
+      },
+    },
+  },
+);
+
+const textVariants = cva("font-normal", {
+  variants: {
+    size: {
+      md: "text-lg",
+      sm: "text-sm",
+    },
+  },
+});
+
+// variants 속성들을 props로 필수로 받도록 함
+interface DropdownProps
+  extends Required<VariantProps<typeof dropdownVariants>> {
+  className?: string;
+}
+
+function Dropdown({ size, className }: DropdownProps) {
+  return (
+    <div className={cn(dropdownVariants({ size }), className)}>
+      {dropdownMenus.map((menu, idx) => (
+        <Link href={"#"} className={cn(textVariants({ size }))} key={idx}>
+          {menu}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+export default Dropdown;


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-74)
  
<br/>

## 📗 작업 내용

- dropdown 컴포넌트를 공통컴포넌트로 분리하였습니다.
- 버튼의 내용과 클릭 시 동작을 직접 설정할 수 있도록 개선하였습니다.
- size를 넘겨주지 않으면 default로 `sm`이 적용됩니다.


### 사용예시
``` tsx

  const dropdownItems = [
    { label: "Edit", onClick: () => alert("Edit clicked") },
    { label: "Delete", onClick: () => alert("Delete clicked") },
    { label: "Share", onClick: () => alert("Share clicked") },
  ];

  <Dropdown items={dropdownItems} size="md"  />

```

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


