### PR TITLE
refactor(TODO-78): 사이드바 리팩터링

### DIFF
--- a/src/views/layouts/organisms/MenuGoal.tsx
+++ b/src/views/layouts/organisms/MenuGoal.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import flag from "@public/icons/flag.png";
 
 import MenuItem from "../atoms/MenuItem";
@@ -5,7 +6,7 @@ import TabSideMenuList from "../molecules/TabSideMenuList";
 
 const items = ["hihihihi"];
 
-export default function MenuGoal() {
+export default memo(function MenuGoal() {
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-3 pt-3">
       <div className="flex justify-between">
@@ -18,4 +19,4 @@ export default function MenuGoal() {
       </div>
     </section>
   );
-}
+});

--- a/src/views/layouts/organisms/SidebarHeader.tsx
+++ b/src/views/layouts/organisms/SidebarHeader.tsx
@@ -1,7 +1,4 @@
 import Image from "next/image";
-import iconFold from "@public/icons/fold.png";
-import logo from "@public/icons/logo.png";
-import logoHorizontal from "@public/icons/logo_horizontal.png";
 import Link from "next/link";
 
 import { cn } from "@/utils/cn";
@@ -23,15 +20,15 @@ export default function SidebarHeader({
       )}
     >
       <Link href="/">
-        <Image
-          src={logoHorizontal}
-          alt="로고"
+        <img
+          src="/icons/logo_horizontal.png"
+          alt="로고_horizontal"
           width={106}
           height={35}
           className={cn(!isOpen && "hidden")}
         />
-        <Image
-          src={logo}
+        <img
+          src="/icons/logo.png"
           alt="로고"
           width={32}
           height={32}
@@ -39,8 +36,8 @@ export default function SidebarHeader({
         />
       </Link>
       <button onClick={onToggleSidebar}>
-        <Image
-          src={iconFold}
+        <img
+          src="/icons/fold.png"
           width={24}
           height={24}
           alt={isOpen ? "사이드바 닫기" : "사이드바 열기"}

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -1,5 +1,4 @@
 import hamburger from "@public/icons/hamburger.png";
-import Image from "next/image";
 import { useEffect, useState } from "react";
 
 import { cn } from "@/utils/cn";
@@ -31,7 +30,7 @@ export default function Sidebar({ title }: { title: string }) {
         className={cn("flex gap-4 px-4 py-3 sm:hidden", isOpen && "hidden")}
       >
         <button onClick={handleToggleSidebar}>
-          <Image src={hamburger} width={24} height={24} alt="메뉴" />
+          <img src="/icons/hamburger.png" width={24} height={24} alt="메뉴" />
         </button>
         <h1 className="text-base font-semibold">{title}</h1>
       </header>


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-78)
  
<br/>

## 📗 작업 내용

- 하위 컴포넌트 MemoGoal에 memo 추가 적용했습니다.
- 작은 아이콘에 기존 next/image -> img 태그로 변경했습니다. 

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


