### PR TITLE
style(TODO-83): 사이드바 스타일 수정

### DIFF
--- a/src/views/layouts/organisms/MenuDashBoard.tsx
+++ b/src/views/layouts/organisms/MenuDashBoard.tsx
@@ -9,7 +9,7 @@ export default memo(function MenuDashboard() {
       <div className="hidden pb-[24px] sm:block">
         <button>새 할일</button>
       </div>
-      <section className="flex h-[60px] items-center justify-between border-t border-b border-slate-200 py-3">
+      <section className="flex h-[36px] items-center justify-between border-t border-b border-slate-200 py-3">
         <MenuItem title="대시보드" icon={home} />
         <button className="sm:hidden">새 할일</button>
       </section>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -64,6 +64,7 @@ export default function Sidebar({ title }: { title: string }) {
           "hidden sm:block md:hidden",
           "after:fixed after:inset-0 after:z-10 after:bg-black/50",
           "after:hidden sm:after:block md:after:hidden",
+          !isOpen && "sm:after:hidden",
         )}
       ></div>
     </>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -37,7 +37,7 @@ export default function Sidebar({ title }: { title: string }) {
       <aside
         className={cn(
           // mobile 스타일
-          "z-20 flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex] ease-[cubic-bezier(0,0.36,0,0.84)]",
+          "z-20 box-border flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex] ease-[cubic-bezier(0,0.36,0,0.84)]",
           // tablet + pc 스타일
           "sm:w-[280px] sm:flex-[0_0_280px] sm:border-r sm:pb-9",
           // tablet:fixed 관련


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-83)
  
<br/>

## 📗 작업 내용

- 전역 content-box로 깨진 스타일 복구
- sm(태블릿) 사이즈에서 사이드바 닫혔을때 backdrop 제거 

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


