### PR TITLE
style(TODO-88): sm 최소 컨텐츠 + 사이드바 오픈 일 때의 스타일 수정

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -60,7 +60,7 @@
   --color-slate-950: #020617;
 
   --breakpoint-sm: 744px;
-  --breakpoint-sm-sidebar: 964px;
+  --breakpoint-smd: 964px;
   --breakpoint-md: 1520px;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -60,6 +60,7 @@
   --color-slate-950: #020617;
 
   --breakpoint-sm: 744px;
+  --breakpoint-sm-sidebar: 964px;
   --breakpoint-md: 1520px;
 }
 

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -40,7 +40,7 @@ export default function Sidebar({ title }: { title: string }) {
           // tablet + pc 스타일
           "sm:w-[280px] sm:flex-[0_0_280px] sm:border-r sm:pb-9",
           // tablet:fixed 관련
-          "sm-sidebar:relative sm:fixed sm:inset-y-0 sm:left-0",
+          "smd:relative sm:fixed sm:inset-y-0 sm:left-0",
           !isOpen && "hidden sm:flex sm:w-[60px] sm:flex-[0_0_60px]",
         )}
       >
@@ -58,12 +58,12 @@ export default function Sidebar({ title }: { title: string }) {
       </aside>
       <div
         className={cn(
-          // sm ~ sm-sidebar 까지 fixed 된 공간 설정
+          // sm ~ smd 까지 fixed 된 공간 설정
           "h-screen w-[60px]",
-          "sm-sidebar:hidden hidden sm:block",
+          "smd:hidden hidden sm:block",
           // backdrop
           "after:fixed after:inset-0 after:z-10 after:bg-black/50 after:opacity-100 after:transition-[opacity] after:delay-[10ms]",
-          "sm-sidebar:after:hidden after:hidden sm:after:block",
+          "smd:after:hidden after:hidden sm:after:block",
           !isOpen && "after:opacity-0 sm:after:hidden",
         )}
       ></div>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -1,4 +1,3 @@
-import hamburger from "@public/icons/hamburger.png";
 import { useEffect, useState } from "react";
 
 import { cn } from "@/utils/cn";
@@ -37,11 +36,11 @@ export default function Sidebar({ title }: { title: string }) {
       <aside
         className={cn(
           // mobile 스타일
-          "z-20 box-border flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex] ease-[cubic-bezier(0,0.36,0,0.84)]",
+          "z-20 box-border flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex,width] ease-[cubic-bezier(0,0.36,0,0.84)]",
           // tablet + pc 스타일
           "sm:w-[280px] sm:flex-[0_0_280px] sm:border-r sm:pb-9",
           // tablet:fixed 관련
-          "sm:fixed sm:inset-y-0 sm:left-0 sm:transition-[width] md:relative",
+          "sm-sidebar:relative sm:fixed sm:inset-y-0 sm:left-0",
           !isOpen && "hidden sm:flex sm:w-[60px] sm:flex-[0_0_60px]",
         )}
       >
@@ -61,9 +60,9 @@ export default function Sidebar({ title }: { title: string }) {
       <div
         className={cn(
           "h-screen w-[60px]",
-          "hidden sm:block md:hidden",
+          "sm-sidebar:hidden hidden sm:block",
           "after:fixed after:inset-0 after:z-10 after:bg-black/50",
-          "after:hidden sm:after:block md:after:hidden",
+          "sm-sidebar::after:hidden after:hidden sm:after:block",
           !isOpen && "sm:after:hidden",
         )}
       ></div>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -59,11 +59,11 @@ export default function Sidebar({ title }: { title: string }) {
       {/* backdrop & tablet:fixed */}
       <div
         className={cn(
-          "h-screen w-[60px]",
+          "h-screen w-[60px] opacity-100 transition-[opacity] delay-[10ms]",
           "sm-sidebar:hidden hidden sm:block",
           "after:fixed after:inset-0 after:z-10 after:bg-black/50",
           "sm-sidebar::after:hidden after:hidden sm:after:block",
-          !isOpen && "sm:after:hidden",
+          !isOpen && "opacity-0 sm:after:hidden",
         )}
       ></div>
     </>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -56,14 +56,15 @@ export default function Sidebar({ title }: { title: string }) {
           <MenuGoal />
         </div>
       </aside>
-      {/* backdrop & tablet:fixed */}
       <div
         className={cn(
-          "h-screen w-[60px] opacity-100 transition-[opacity] delay-[10ms]",
+          // sm ~ sm-sidebar 까지 fixed 된 공간 설정
+          "h-screen w-[60px]",
           "sm-sidebar:hidden hidden sm:block",
-          "after:fixed after:inset-0 after:z-10 after:bg-black/50",
+          // backdrop
+          "after:fixed after:inset-0 after:z-10 after:bg-black/50 after:opacity-100 after:transition-[opacity] after:delay-[10ms]",
           "sm-sidebar:after:hidden after:hidden sm:after:block",
-          !isOpen && "opacity-0 sm:after:hidden",
+          !isOpen && "after:opacity-0 sm:after:hidden",
         )}
       ></div>
     </>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -62,7 +62,7 @@ export default function Sidebar({ title }: { title: string }) {
           "h-screen w-[60px] opacity-100 transition-[opacity] delay-[10ms]",
           "sm-sidebar:hidden hidden sm:block",
           "after:fixed after:inset-0 after:z-10 after:bg-black/50",
-          "sm-sidebar::after:hidden after:hidden sm:after:block",
+          "sm-sidebar:after:hidden after:hidden sm:after:block",
           !isOpen && "opacity-0 sm:after:hidden",
         )}
       ></div>


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-88)
  
<br/>

## 📗 작업 내용

- 964px을 넘을 시 pc와 동일하게 사이드바가 동작하도록 수정했습니다.
- sm(태블릿) 과 md(PC) 크기 사이의 스타일 변수를 추가했습니다 
   (smd : small + medium)
- sm 사이즈에서의 컨텐츠 영역(636px) + 사이드바 크기(280px) = 916px 
   916px + x축 패딩(24px + 24px) = 964px
  임을 고려하여 smd는 964px로 설정했습니다.

<img width="250" alt="스크린샷 2025-02-13 오후 6 05 07" src="https://github.com/user-attachments/assets/928c974a-8611-42ba-8d52-ff6d6ca634d3" />


## 💬 리뷰 요구사항(선택)


https://github.com/user-attachments/assets/07599671-ab50-4853-a92f-be4cfdf521ea




