### PR TITLE
fix(TODO-102): Instance 에러 케이스 수정

### DIFF
--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,5 +1,7 @@
-import axios from "axios";
 import type { AxiosError, AxiosInstance } from "axios";
+import axios from "axios";
+
+import { ErrorResponsePayload } from "@/types/types";
 
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BACKEND_URL,
@@ -31,19 +33,17 @@ const handleError = (error: AxiosError): Promise<never> => {
     return Promise.reject(new Error("서버로부터 응답이 없습니다."));
   }
 
-  // error.response 존재할 때
-  const errorMessages: Record<number, string> = {
-    400: "잘못된 요청입니다.",
-    401: "인증에 실패했습니다.",
-    403: "접근 권한이 없습니다.",
-    404: "요청한 페이지를 찾을 수 없습니다.",
-    500: "서버에 오류가 발생했습니다.",
-  };
+  const { status, data } = error.response;
+  const serverMessage = (data as ErrorResponsePayload).message;
+
+  // 401 고정 메시지
+  if (status === 401) {
+    return Promise.reject(new Error("인증에 실패했습니다."));
+  }
+
+  // 나머지는 서버 메시지 우선
   return Promise.reject(
-    new Error(
-      errorMessages[error.response.status] ||
-        `오류가 발생했습니다: ${error.response.status}`,
-    ),
+    new Error(serverMessage || `오류가 발생했습니다: ${status}`),
   );
 };
 

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -33,18 +33,19 @@ const handleError = (error: AxiosError): Promise<never> => {
     return Promise.reject(new Error("서버로부터 응답이 없습니다."));
   }
 
-  const { status, data } = error.response;
-  const serverMessage = (data as ErrorResponsePayload).message;
+  const errorMessages: Record<number, string> = {
+    401: "인증에 실패했습니다.",
+  };
 
-  // 401 고정 메시지
-  if (status === 401) {
-    return Promise.reject(new Error("인증에 실패했습니다."));
+  if (error.response) {
+    const data = error.response.data as ErrorResponsePayload;
+    error.message =
+      errorMessages[error.response.status] ||
+      data.message ||
+      `오류가 발생했습니다. (코드: ${error.response.status})`;
   }
 
-  // 나머지는 서버 메시지 우선
-  return Promise.reject(
-    new Error(serverMessage || `오류가 발생했습니다: ${status}`),
-  );
+  return Promise.reject(error);
 };
 
 export default instance;


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-102)
  
<br/>

## 📗 작업 내용

> 401 Unauthorized

![localhost_3000_todo - Chrome 2025-02-14 오후 1_41_49](https://github.com/user-attachments/assets/7b9f4051-f62a-406a-889b-a8147edd3d0d)

> 서버 메시지 있을 때

![localhost_3000_todo - Chrome 2025-02-14 오후 1_42_09](https://github.com/user-attachments/assets/103bc734-ff07-4b0b-b27d-e84b5a0ec3d5)
![localhost_3000_todo - Chrome 2025-02-14 오후 1_42_20](https://github.com/user-attachments/assets/482a0939-d0bd-472c-8f72-51281dde2f1f)

> 메시지 없을 경우

![localhost_3000_todo - Chrome 2025-02-14 오후 1_48_16](https://github.com/user-attachments/assets/10835dd1-e28a-4a82-8613-b709c3a114cf)


<br/>


## 💬 리뷰 요구사항(선택)

- 메시지 없을 경우는 신경 안 써도 되겠습니다!


