### PR TITLE
style(TODO-110): 할 일 목록 컴포넌트 스타일 수정

### DIFF
--- a/src/components/atoms/action-icon/ActionIcon.tsx
+++ b/src/components/atoms/action-icon/ActionIcon.tsx
@@ -50,7 +50,7 @@ export function ActionIcon({
   ].filter(Boolean) as ActionOptions[];
 
   return (
-    <ul className="flex transition">
+    <ul className="flex flex-shrink-0 transition">
       {actions.map(({ src, alt, className, onClick, role }, index) => (
         <li
           key={index}

--- a/src/components/atoms/todo-checkbox/TodoCheckbox.tsx
+++ b/src/components/atoms/todo-checkbox/TodoCheckbox.tsx
@@ -7,7 +7,7 @@ export function TodoCheckbox({ done, onToggle }: TodoCheckboxProps) {
   return (
     <button
       onClick={onToggle}
-      className="mr-2 flex cursor-pointer items-center p-[3px]"
+      className="mr-2 flex flex-shrink-0 cursor-pointer items-center p-[3px]"
     >
       <img
         src={done ? "/active-check.png" : "/inactive-check.png"}

--- a/src/components/atoms/todo-title/TodoTitle.tsx
+++ b/src/components/atoms/todo-title/TodoTitle.tsx
@@ -9,7 +9,7 @@ export function TodoTitle({ title, done }: TodoTitleProps) {
   return (
     <span
       className={cn(
-        "cursor-default transition-all duration-150 group-hover:text-blue-500",
+        "cursor-default truncate transition-all duration-150 group-hover:text-blue-500",
         done ? "line-through" : "",
       )}
     >

--- a/src/components/molecules/todo-item/TodoItem.tsx
+++ b/src/components/molecules/todo-item/TodoItem.tsx
@@ -23,7 +23,7 @@ export function TodoItem({
         done={todo.done}
         onToggle={() => handleToggleTodo(todo.id, todo.done)}
       />
-      <div className="flex w-full items-center justify-between">
+      <div className="flex w-full min-w-0 items-center justify-between">
         <TodoTitle title={todo.title} done={todo.done} />
         <ActionIcon
           todo={todo}


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-110)
  
<br/>

## 📗 작업 내용

- 넘칠 경우 말줄임표로 한 줄에서 잘리도록 수정
- 내용이 꽉 찰 때 이미지가 줄어드는 현상도 발견되어 수정

> 피그마

![KDT 단기심화  슬리드 투 두 – Figma - 개인 - Microsoft​ Edge 2025-02-14 오후 7_49_33](https://github.com/user-attachments/assets/02e62667-c672-447c-b636-5e1f8cb47121)

> 수정 적용

![localhost_3000_todo - Chrome 2025-02-14 오후 7_51_44](https://github.com/user-attachments/assets/23e47ad9-66bf-4f96-9b63-b251f05c061f)

<br/>

## 💬 리뷰 요구사항(선택)

- 기능 요구사항엔 없지만 피그마엔 따로 할 일 아래 노트가 표시되어있어서 구현방법 생각해보려고 합니다.

![KDT 단기심화  슬리드 투 두 – Figma - 개인 - Microsoft​ Edge 2025-02-14 오후 7_56_16](https://github.com/user-attachments/assets/296b6047-b564-4c9f-bb02-5b04e572234a)

