### PR TITLE
feat(TODO-111): PlusIcon 컴포넌트 구현

### DIFF
--- a/src/components/atoms/plus-icon/PlusIcon.stories.ts
+++ b/src/components/atoms/plus-icon/PlusIcon.stories.ts
@@ -1,0 +1,35 @@
+import PlusIcon from "./PlusIcon";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Common/Atoms/PlusIcon",
+  component: PlusIcon,
+  argTypes: {
+    width: {
+      control: "number",
+      defaultValue: 24,
+    },
+    height: {
+      control: "number",
+      defaultValue: 24,
+    },
+    color: {
+      control: "color",
+    },
+    className: {
+      control: "text",
+    },
+  },
+} satisfies Meta<typeof PlusIcon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    width: 24,
+    height: 24,
+    color: "#3b82f6",
+  },
+};

--- a/src/components/atoms/plus-icon/PlusIcon.tsx
+++ b/src/components/atoms/plus-icon/PlusIcon.tsx
@@ -22,14 +22,14 @@ export default function PlusIcon({
       <path
         d="M5 12H18.5"
         stroke="currentColor"
-        stroke-width="1.8"
-        stroke-linecap="round"
+        strokeWidth="1.8"
+        strokeLinecap="round"
       />
       <path
         d="M11.75 18.75V5.25"
         stroke="currentColor"
-        stroke-width="1.8"
-        stroke-linecap="round"
+        strokeWidth="1.8"
+        strokeLinecap="round"
       />
     </svg>
   );

--- a/src/components/atoms/plus-icon/PlusIcon.tsx
+++ b/src/components/atoms/plus-icon/PlusIcon.tsx
@@ -1,0 +1,30 @@
+type PlusIconProps = Pick<
+  React.SVGProps<SVGSVGElement>,
+  "width" | "height" | "color"
+>;
+
+export default function PlusIcon({ width, height, color }: PlusIconProps) {
+  return (
+    <svg
+      width={width || 24}
+      height={height || 24}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      color={color}
+    >
+      <path
+        d="M5 12H18.5"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+      />
+      <path
+        d="M11.75 18.75V5.25"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/atoms/plus-icon/PlusIcon.tsx
+++ b/src/components/atoms/plus-icon/PlusIcon.tsx
@@ -1,9 +1,14 @@
 type PlusIconProps = Pick<
   React.SVGProps<SVGSVGElement>,
-  "width" | "height" | "color"
+  "width" | "height" | "color" | "className"
 >;
 
-export default function PlusIcon({ width, height, color }: PlusIconProps) {
+export default function PlusIcon({
+  width,
+  height,
+  color,
+  className,
+}: PlusIconProps) {
   return (
     <svg
       width={width || 24}
@@ -12,6 +17,7 @@ export default function PlusIcon({ width, height, color }: PlusIconProps) {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       color={color}
+      className={className}
     >
       <path
         d="M5 12H18.5"


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-111)
  
<br/>

## 📗 작업 내용

- PlusIcon 컴포넌트를 구현했습니다.
- width, height의 기본값은 24로 크기를 수정하고 싶을 땐 props로 변경하면 됩니다.
- 색상은 부모 요소의 색상을 따라갑니다. 직접 부여하고 싶을 시엔 아래 두가지 중에서 선택하면 됩니다.
  -  color props를 넘기기
  -  className으로 text color값 넘기기 

```
      // 색상 설정
      <div className="text-blue-700" >
        <PlusIcon />
      </div>
      <PlusIcon color="#2563eb" />
      <PlusIcon className="text-blue-700" />

      // 크기 설정
      <PlusIcon width={16} height={16} />
```


<br/>


## 💬 리뷰 요구사항(선택)

- Plus 이미지를 색상, 크기별로 다양하게 적용하는 곳이 많아 svg형태의 컴포넌트를 추가하는게 효율적이라고 생각해서 추가했습니다.


