### PR TITLE
feat(TODO-107): 컴포넌트 분리

### DIFF
--- a/src/views/layouts/atoms/AddButton.tsx
+++ b/src/views/layouts/atoms/AddButton.tsx
@@ -1,0 +1,36 @@
+import { HTMLAttributes } from "react";
+
+import Button from "@/components/atoms/button/Button";
+import PlusIcon from "@/components/atoms/plus-icon/PlusIcon";
+import { cn } from "@/utils/cn";
+
+interface ButtonPlusIconProps extends HTMLAttributes<HTMLButtonElement> {
+  size?: "default" | "xs";
+  outline?: boolean;
+}
+
+export default function AddButton({
+  size = "default",
+  outline = false,
+  className,
+  children,
+  ...props
+}: ButtonPlusIconProps) {
+  const isSmallSize = size === "xs";
+  const iconSize = isSmallSize ? 16 : 24;
+
+  return (
+    <Button
+      size={isSmallSize ? "xs" : "default"}
+      variant={outline ? "outline" : "default"}
+      className={cn(
+        isSmallSize ? "sm:hidden" : "hidden sm:inline-flex",
+        className,
+      )}
+      {...props}
+    >
+      <PlusIcon width={iconSize} height={iconSize} />
+      <span className={cn(isSmallSize ? "px-0.5" : "px-1")}>{children}</span>
+    </Button>
+  );
+}

--- a/src/views/layouts/atoms/AddButton.tsx
+++ b/src/views/layouts/atoms/AddButton.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, memo } from "react";
 
 import Button from "@/components/atoms/button/Button";
 import PlusIcon from "@/components/atoms/plus-icon/PlusIcon";
@@ -9,7 +9,7 @@ interface ButtonPlusIconProps extends HTMLAttributes<HTMLButtonElement> {
   outline?: boolean;
 }
 
-export default function AddButton({
+export default memo(function AddButton({
   size = "default",
   outline = false,
   className,
@@ -33,4 +33,4 @@ export default function AddButton({
       <span className={cn(isSmallSize ? "px-0.5" : "px-1")}>{children}</span>
     </Button>
   );
-}
+});

--- a/src/views/layouts/atoms/MenuItem.tsx
+++ b/src/views/layouts/atoms/MenuItem.tsx
@@ -1,15 +1,14 @@
-import Image, { ImageProps } from "next/image";
-import { memo } from "react";
+import { ImgHTMLAttributes, memo } from "react";
 
 interface MenuItemProps {
   title: string;
-  icon: ImageProps["src"];
+  iconSrc: ImgHTMLAttributes<HTMLImageElement>["src"];
 }
 
-export default memo(function MenuItem({ title, icon }: MenuItemProps) {
+export default memo(function MenuItem({ title, iconSrc }: MenuItemProps) {
   return (
     <div className="flex items-center gap-2">
-      <Image src={icon} width={24} height={24} alt={title} />
+      <img src={iconSrc} width={24} height={24} alt={title} />
       <span className="text-lg font-medium">{title}</span>
     </div>
   );

--- a/src/views/layouts/molecules/GoalCreationForm.tsx
+++ b/src/views/layouts/molecules/GoalCreationForm.tsx
@@ -1,15 +1,22 @@
 import { memo } from "react";
 
+import { cn } from "@/utils/cn";
+
 type GoalCreationFormProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  isVisible: boolean;
 };
 
 export default memo(function GoalCreationForm({
   onSubmit,
+  isVisible,
 }: GoalCreationFormProps) {
   return (
     <form
-      className="box-border flex w-full flex-col gap-2 rounded-lg bg-white px-2 text-sm font-medium"
+      className={cn(
+        "box-border flex w-full flex-col gap-2 rounded-lg bg-white px-2 text-sm font-medium",
+        { hidden: !isVisible },
+      )}
       onSubmit={onSubmit}
     >
       <div className="flex w-full items-center gap-1">

--- a/src/views/layouts/molecules/GoalCreationForm.tsx
+++ b/src/views/layouts/molecules/GoalCreationForm.tsx
@@ -1,8 +1,12 @@
+import { memo } from "react";
+
 type GoalCreationFormProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
 };
 
-export default function GoalCreationForm({ onSubmit }: GoalCreationFormProps) {
+export default memo(function GoalCreationForm({
+  onSubmit,
+}: GoalCreationFormProps) {
   return (
     <form
       className="box-border flex w-full flex-col gap-2 rounded-lg bg-white px-2 text-sm font-medium"
@@ -19,4 +23,4 @@ export default function GoalCreationForm({ onSubmit }: GoalCreationFormProps) {
       </div>
     </form>
   );
-}
+});

--- a/src/views/layouts/molecules/GoalCreationForm.tsx
+++ b/src/views/layouts/molecules/GoalCreationForm.tsx
@@ -1,0 +1,22 @@
+type GoalCreationFormProps = {
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+};
+
+export default function GoalCreationForm({ onSubmit }: GoalCreationFormProps) {
+  return (
+    <form
+      className="box-border flex w-full flex-col gap-2 rounded-lg bg-white px-2 text-sm font-medium"
+      onSubmit={onSubmit}
+    >
+      <div className="flex w-full items-center gap-1">
+        <span>•</span>
+        <input
+          placeholder="목표를 입력하세요"
+          autoFocus
+          name="title"
+          className="w-full rounded bg-slate-100 p-2 text-base outline-none sm:text-sm"
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/views/layouts/molecules/TabSideMenuList.tsx
+++ b/src/views/layouts/molecules/TabSideMenuList.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react";
+
 import { TeamIdGoalsGet200Response } from "@/types/types";
 
 import TabSideMenuItem from "../atoms/TabSideMenuItem";
@@ -6,7 +8,7 @@ interface TabSideMenuItemProps {
   items: TeamIdGoalsGet200Response["goals"];
 }
 
-export default function TabSideMenuList({ items }: TabSideMenuItemProps) {
+export default memo(function TabSideMenuList({ items }: TabSideMenuItemProps) {
   return (
     <ul className="flex-1 overflow-auto">
       {items.map((item) => (
@@ -14,4 +16,4 @@ export default function TabSideMenuList({ items }: TabSideMenuItemProps) {
       ))}
     </ul>
   );
-}
+});

--- a/src/views/layouts/organisms/MenuDashBoard.tsx
+++ b/src/views/layouts/organisms/MenuDashBoard.tsx
@@ -1,5 +1,4 @@
 import { memo } from "react";
-import home from "@public/icons/home.png";
 
 import AddButton from "../atoms/AddButton";
 import MenuItem from "../atoms/MenuItem";
@@ -11,7 +10,7 @@ export default memo(function MenuDashboard() {
         <AddButton>새 할일</AddButton>
       </div>
       <section className="flex h-[36px] items-center justify-between border-t border-b border-slate-200 py-3">
-        <MenuItem title="대시보드" icon={home} />
+        <MenuItem title="대시보드" iconSrc="/icons/home.png" />
         <AddButton size="xs">새 할일</AddButton>
       </section>
     </>

--- a/src/views/layouts/organisms/MenuDashBoard.tsx
+++ b/src/views/layouts/organisms/MenuDashBoard.tsx
@@ -1,17 +1,18 @@
 import { memo } from "react";
 import home from "@public/icons/home.png";
 
+import AddButton from "../atoms/AddButton";
 import MenuItem from "../atoms/MenuItem";
 
 export default memo(function MenuDashboard() {
   return (
     <>
       <div className="hidden pb-[24px] sm:block">
-        <button>새 할일</button>
+        <AddButton>새 할일</AddButton>
       </div>
       <section className="flex h-[36px] items-center justify-between border-t border-b border-slate-200 py-3">
         <MenuItem title="대시보드" icon={home} />
-        <button className="sm:hidden">새 할일</button>
+        <AddButton size="xs">새 할일</AddButton>
       </section>
     </>
   );

--- a/src/views/layouts/organisms/MenuGoal.tsx
+++ b/src/views/layouts/organisms/MenuGoal.tsx
@@ -1,4 +1,3 @@
-import flag from "@public/icons/flag.png";
 import { FormEventHandler, memo, useRef, useState } from "react";
 
 import { useCreateGoal } from "@/hooks/goal/useCreateGoal";
@@ -39,7 +38,7 @@ export default memo(function MenuGoal() {
     <>
       <section className="flex min-h-0 flex-1 flex-col gap-3 pt-3">
         <div className="flex justify-between">
-          <MenuItem title="목표" icon={flag} />
+          <MenuItem title="목표" iconSrc="/icons/flag.png" />
           <AddButton
             size="xs"
             outline


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-107)
  
<br/>

## 📗 작업 내용

- 기존에 한 파일에 있던 내용을 컴포넌트로 분리했습니다. (AddButton, GoalCreationForm)
- input은 공통 컴포넌트 UI와 달라 적용하지 않았습니다.
- Input의 value를 state 적용하지 않고 form에서 처리할 수 있도록 변경했습니다.

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


