### PR TITLE
feat(TODO-114): 목표 무한 스크롤 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "react-intersection-observer": "^9.15.1",
     "tailwind-merge": "^3.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@19.0.0)
+      react-intersection-observer:
+        specifier: ^9.15.1
+        version: 9.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.0.1
@@ -4549,6 +4552,15 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-intersection-observer@9.15.1:
+    resolution: {integrity: sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -8728,7 +8740,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8750,7 +8762,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10662,6 +10674,12 @@ snapshots:
   react-hook-form@7.54.2(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  react-intersection-observer@9.15.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
 
   react-is@16.13.1: {}
 

--- a/src/hooks/goal/useCreateGoal.ts
+++ b/src/hooks/goal/useCreateGoal.ts
@@ -7,7 +7,12 @@ const getLastGoalId = (goalList: TeamIdGoalsGet200Response["goals"]) => {
   return goalList.length ? goalList[goalList.length - 1].id : -1;
 };
 
-export const useCreateGoal = () => {
+interface useCreatieGoalProps {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export const useCreateGoal = (config: useCreatieGoalProps) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -16,30 +21,48 @@ export const useCreateGoal = () => {
       await instance.post("/goals", { title: content }),
     onMutate: async (newGoal: string) => {
       await queryClient.cancelQueries({ queryKey: ["goals"] });
-      const previousTodos = queryClient.getQueryData(["goals"]);
 
-      if (previousTodos) {
-        const setNewGoalData = (old: TeamIdGoalsGet200Response) => ({
-          ...old,
-          goals: [
-            ...old.goals,
-            { id: `temp_${getLastGoalId(old.goals) + 1}`, title: newGoal },
-          ],
-        });
+      const previousGoals = queryClient.setQueryData(
+        ["goals"],
+        (oldData: {
+          pages: TeamIdGoalsGet200Response[];
+          pageParams: number;
+        }) => {
+          if (!oldData) return oldData;
 
-        queryClient.setQueryData(["goals"], setNewGoalData);
-      }
+          const newGoalItem = {
+            id: `temp_${getLastGoalId(oldData.pages[0].goals) + 1}`,
+            title: newGoal,
+          };
 
-      return { previousTodos };
+          return {
+            pages: [
+              {
+                ...oldData.pages[0],
+                goals: [newGoalItem, ...oldData.pages[0].goals],
+              },
+              ...oldData.pages.slice(1),
+            ],
+            pageParams: oldData.pageParams,
+          };
+        },
+      );
+
+      return { previousGoals };
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["goals"] });
+      if (confirm("목표가 추가되었습니다.")) {
+        config?.onSuccess?.();
+      }
     },
     onError: (error, _, context) => {
-      if (context?.previousTodos) {
-        queryClient.setQueryData(["goals"], context?.previousTodos);
+      if (context?.previousGoals) {
+        queryClient.setQueryData(["goals"], context?.previousGoals);
       }
-      alert(error);
+
+      if (config?.onError) {
+        config.onError(error);
+      }
     },
   });
 };

--- a/src/hooks/goal/useIniniteGoals.ts
+++ b/src/hooks/goal/useIniniteGoals.ts
@@ -41,7 +41,7 @@ export default function useInfiniteGoals<
   // 스크롤 감지 블럭이 항상 true인 경우(자식 요소의 높이 <= 부모 요소의 높이), 추가 데이터 가져오기
   useEffect(() => {
     const parentEl = (parentRef as RefObject<T>)?.current;
-    const childEl = (childRef as RefObject<T>)?.current;
+    const childEl = (childRef as RefObject<U>)?.current;
 
     if (!parentEl || !childEl) {
       return;
@@ -60,7 +60,7 @@ export default function useInfiniteGoals<
   // 스크롤 감지 블럭이 동작하는 경우(자식 요소의 높이 > 부모 요소의 높이), 무한 스크롤 처리
   useEffect(() => {
     const parentEl = (parentRef as RefObject<T>)?.current;
-    const childEl = (childRef as RefObject<T>)?.current;
+    const childEl = (childRef as RefObject<U>)?.current;
 
     if (!parentEl || !childEl) {
       return;

--- a/src/hooks/goal/useIniniteGoals.ts
+++ b/src/hooks/goal/useIniniteGoals.ts
@@ -8,7 +8,7 @@ import { TeamIdGoalsGet200Response, teamIdGoalsGetParams } from "@/types/types";
 export default function useInfiniteGoals<
   T extends HTMLElement | null,
   U extends HTMLElement | null,
->(parentRef: Ref<T>, childRef: RefObject<U>) {
+>(parentRef: Ref<T>, childRef: Ref<U>) {
   const query = useInfiniteQuery<
     TeamIdGoalsGet200Response,
     Error,
@@ -41,7 +41,7 @@ export default function useInfiniteGoals<
   // 스크롤 감지 블럭이 항상 true인 경우(자식 요소의 높이 <= 부모 요소의 높이), 추가 데이터 가져오기
   useEffect(() => {
     const parentEl = (parentRef as RefObject<T>)?.current;
-    const childEl = childRef?.current;
+    const childEl = (childRef as RefObject<T>)?.current;
 
     if (!parentEl || !childEl) {
       return;
@@ -60,7 +60,7 @@ export default function useInfiniteGoals<
   // 스크롤 감지 블럭이 동작하는 경우(자식 요소의 높이 > 부모 요소의 높이), 무한 스크롤 처리
   useEffect(() => {
     const parentEl = (parentRef as RefObject<T>)?.current;
-    const childEl = childRef?.current;
+    const childEl = (childRef as RefObject<T>)?.current;
 
     if (!parentEl || !childEl) {
       return;

--- a/src/hooks/goal/useIniniteGoals.ts
+++ b/src/hooks/goal/useIniniteGoals.ts
@@ -1,0 +1,75 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Ref, RefObject, useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+
+import instance from "@/apis/apiClient";
+import { TeamIdGoalsGet200Response, teamIdGoalsGetParams } from "@/types/types";
+
+export default function useInfiniteGoals<
+  T extends HTMLElement | null,
+  U extends HTMLElement | null,
+>(parentRef: Ref<T>, childRef: RefObject<U>) {
+  const query = useInfiniteQuery<
+    TeamIdGoalsGet200Response,
+    Error,
+    TeamIdGoalsGet200Response["goals"]
+  >({
+    queryKey: ["goals"],
+    queryFn: async ({ pageParam }) => {
+      const params: teamIdGoalsGetParams = {
+        sortOrder: "newest",
+        size: 10,
+        cursor: pageParam as number,
+      };
+
+      const { data } = await instance.get("/goals", { params });
+
+      return data;
+    },
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    select: (data) => data.pages.map((page) => [...page.goals]).flat(),
+  });
+
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
+
+  const { ref: inViewRef, inView } = useInView({
+    root: (parentRef as RefObject<T>)?.current,
+    threshold: 0,
+  });
+
+  // 스크롤 감지 블럭이 항상 true인 경우(자식 요소의 높이 <= 부모 요소의 높이), 추가 데이터 가져오기
+  useEffect(() => {
+    const parentEl = (parentRef as RefObject<T>)?.current;
+    const childEl = childRef?.current;
+
+    if (!parentEl || !childEl) {
+      return;
+    }
+
+    if (
+      inView &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      childEl.scrollHeight <= parentEl.clientHeight
+    ) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage]);
+
+  // 스크롤 감지 블럭이 동작하는 경우(자식 요소의 높이 > 부모 요소의 높이), 무한 스크롤 처리
+  useEffect(() => {
+    const parentEl = (parentRef as RefObject<T>)?.current;
+    const childEl = childRef?.current;
+
+    if (!parentEl || !childEl) {
+      return;
+    }
+
+    if (inView && hasNextPage && childEl.scrollHeight > parentEl.clientHeight) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage]);
+
+  return { query, inViewRef };
+}

--- a/src/views/layouts/molecules/GoalCreationForm.tsx
+++ b/src/views/layouts/molecules/GoalCreationForm.tsx
@@ -1,33 +1,21 @@
-import { memo } from "react";
-
-import { cn } from "@/utils/cn";
+import Input from "@/components/atoms/input/Input";
 
 type GoalCreationFormProps = {
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  isVisible: boolean;
 };
 
-export default memo(function GoalCreationForm({
-  onSubmit,
-  isVisible,
-}: GoalCreationFormProps) {
+export default (function GoalCreationForm({ onSubmit }: GoalCreationFormProps) {
   return (
     <form
-      className={cn(
-        "box-border flex w-full flex-col gap-2 rounded-lg bg-white px-2 text-sm font-medium",
-        { hidden: !isVisible },
-      )}
+      className="box-border flex w-full flex-col gap-2 rounded-lg bg-white text-sm font-medium"
       onSubmit={onSubmit}
     >
-      <div className="flex w-full items-center gap-1">
-        <span>•</span>
-        <input
-          placeholder="목표를 입력하세요"
-          autoFocus
-          name="title"
-          className="w-full rounded bg-slate-100 p-2 text-base outline-none sm:text-sm"
-        />
-      </div>
+      <Input
+        placeholder="목표를 입력하세요"
+        autoFocus
+        name="title"
+        className="rounded-[12px]"
+      />
     </form>
   );
 });

--- a/src/views/layouts/molecules/TabSideMenuList.tsx
+++ b/src/views/layouts/molecules/TabSideMenuList.tsx
@@ -1,20 +1,32 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { memo, useEffect, useRef } from "react";
+import { forwardRef, memo, Ref, useEffect, useRef } from "react";
 import { useInView } from "react-intersection-observer";
 
 import instance from "@/apis/apiClient";
 import { TeamIdGoalsGet200Response, teamIdGoalsGetParams } from "@/types/types";
+import { cn } from "@/utils/cn";
 
 import TabSideMenuItem from "../atoms/TabSideMenuItem";
 
-export default memo(function TabSideMenuList() {
-  const { data, fetchNextPage, hasNextPage, isError, error } =
-    useInfiniteQuery<TeamIdGoalsGet200Response>({
+export default memo(
+  forwardRef(function TabSideMenuList(_, ref: Ref<HTMLDivElement | null>) {
+    const {
+      data,
+      fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+      isError,
+      error,
+    } = useInfiniteQuery<
+      TeamIdGoalsGet200Response,
+      Error,
+      TeamIdGoalsGet200Response["goals"]
+    >({
       queryKey: ["goals"],
       queryFn: async ({ pageParam }) => {
         const params: teamIdGoalsGetParams = {
           sortOrder: "newest",
-          size: 20,
+          size: 10,
           cursor: pageParam as number,
         };
 
@@ -24,33 +36,67 @@ export default memo(function TabSideMenuList() {
       },
       initialPageParam: null,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
+      select: (data) => data.pages.map((page) => [...page.goals]).flat(),
     });
 
-  const goals = data?.pages.map((page) => [...page.goals]).flat();
+    const ulRef = useRef<HTMLUListElement>(null);
 
-  const ref = useRef<HTMLUListElement>(null);
+    const { ref: inViewRef, inView } = useInView({
+      root: (ref as React.RefObject<HTMLDivElement>)?.current,
+      threshold: 1,
+    });
 
-  const { ref: inViewRef, inView } = useInView({
-    root: ref.current,
-    threshold: 1,
-  });
+    useEffect(() => {
+      const divEl = (ref as React.RefObject<HTMLDivElement>)?.current;
+      const ulEl = ulRef?.current;
 
-  useEffect(() => {
-    if (inView && hasNextPage) {
-      fetchNextPage();
+      if (!divEl || !ulEl) {
+        return;
+      }
+
+      if (
+        inView &&
+        hasNextPage &&
+        !isFetchingNextPage &&
+        ulEl.scrollHeight <= divEl.clientHeight
+      ) {
+        fetchNextPage();
+      }
+    }, [inView, hasNextPage, isFetchingNextPage]);
+
+    useEffect(() => {
+      const divEl = (ref as React.RefObject<HTMLDivElement>)?.current;
+      const ulEl = ulRef?.current;
+
+      if (!divEl || !ulEl) {
+        return;
+      }
+
+      if (inView && hasNextPage && ulEl.scrollHeight > divEl.clientHeight) {
+        fetchNextPage();
+      }
+    }, [inView, hasNextPage]);
+
+    if (isError) {
+      return <p>에러 발생: {(error as Error).message}</p>;
     }
-  }, [inView, hasNextPage]);
 
-  if (isError) {
-    <p>에러 발생: {(error as Error).message}</p>;
-  }
-
-  return (
-    <ul className="flex min-h-0 flex-1 flex-col overflow-auto" ref={ref}>
-      {goals?.map((item) => (
-        <TabSideMenuItem key={item.id} content={item.title} />
-      ))}
-      {goals?.length && <li ref={inViewRef}>hi</li>}
-    </ul>
-  );
-});
+    return (
+      <div
+        className={cn(
+          "relative flex min-h-0 flex-1 flex-col overflow-hidden",
+          hasNextPage &&
+            "after:absolute after:inset-x-0 after:bottom-0 after:h-1/3 after:max-h-[80px] after:bg-[linear-gradient(180deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.6)_57%,rgba(255,255,255,0.8)_100%)]",
+        )}
+        ref={ref}
+      >
+        <ul className="min-h-0 flex-1 overflow-auto" ref={ulRef}>
+          {data?.map((goal) => (
+            <TabSideMenuItem key={goal.id} content={goal.title} />
+          ))}
+          {data?.length && <li ref={inViewRef}></li>}
+        </ul>
+      </div>
+    );
+  }),
+);

--- a/src/views/layouts/molecules/TabSideMenuList.tsx
+++ b/src/views/layouts/molecules/TabSideMenuList.tsx
@@ -1,19 +1,56 @@
-import { memo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { memo, useEffect, useRef } from "react";
+import { useInView } from "react-intersection-observer";
 
-import { TeamIdGoalsGet200Response } from "@/types/types";
+import instance from "@/apis/apiClient";
+import { TeamIdGoalsGet200Response, teamIdGoalsGetParams } from "@/types/types";
 
 import TabSideMenuItem from "../atoms/TabSideMenuItem";
 
-interface TabSideMenuItemProps {
-  items: TeamIdGoalsGet200Response["goals"];
-}
+export default memo(function TabSideMenuList() {
+  const { data, fetchNextPage, hasNextPage, isError, error } =
+    useInfiniteQuery<TeamIdGoalsGet200Response>({
+      queryKey: ["goals"],
+      queryFn: async ({ pageParam }) => {
+        const params: teamIdGoalsGetParams = {
+          sortOrder: "newest",
+          size: 20,
+          cursor: pageParam as number,
+        };
 
-export default memo(function TabSideMenuList({ items }: TabSideMenuItemProps) {
+        const { data } = await instance.get("/goals", { params });
+
+        return data;
+      },
+      initialPageParam: null,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    });
+
+  const goals = data?.pages.map((page) => [...page.goals]).flat();
+
+  const ref = useRef<HTMLUListElement>(null);
+
+  const { ref: inViewRef, inView } = useInView({
+    root: ref.current,
+    threshold: 1,
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage]);
+
+  if (isError) {
+    <p>에러 발생: {(error as Error).message}</p>;
+  }
+
   return (
-    <ul className="flex-1 overflow-auto">
-      {items.map((item) => (
+    <ul className="flex min-h-0 flex-1 flex-col overflow-auto" ref={ref}>
+      {goals?.map((item) => (
         <TabSideMenuItem key={item.id} content={item.title} />
       ))}
+      {goals?.length && <li ref={inViewRef}>hi</li>}
     </ul>
   );
 });

--- a/src/views/layouts/molecules/TabSideMenuList.tsx
+++ b/src/views/layouts/molecules/TabSideMenuList.tsx
@@ -1,81 +1,17 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { forwardRef, memo, Ref, useEffect, useRef } from "react";
-import { useInView } from "react-intersection-observer";
+import { ForwardedRef, forwardRef, memo, useRef } from "react";
 
-import instance from "@/apis/apiClient";
-import { TeamIdGoalsGet200Response, teamIdGoalsGetParams } from "@/types/types";
+import useInfiniteGoals from "@/hooks/goal/useIniniteGoals";
 import { cn } from "@/utils/cn";
 
 import TabSideMenuItem from "../atoms/TabSideMenuItem";
 
 export default memo(
-  forwardRef(function TabSideMenuList(_, ref: Ref<HTMLDivElement | null>) {
-    const {
-      data,
-      fetchNextPage,
-      hasNextPage,
-      isFetchingNextPage,
-      isError,
-      error,
-    } = useInfiniteQuery<
-      TeamIdGoalsGet200Response,
-      Error,
-      TeamIdGoalsGet200Response["goals"]
-    >({
-      queryKey: ["goals"],
-      queryFn: async ({ pageParam }) => {
-        const params: teamIdGoalsGetParams = {
-          sortOrder: "newest",
-          size: 10,
-          cursor: pageParam as number,
-        };
-
-        const { data } = await instance.get("/goals", { params });
-
-        return data;
-      },
-      initialPageParam: null,
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-      select: (data) => data.pages.map((page) => [...page.goals]).flat(),
-    });
-
+  forwardRef(function TabSideMenuList(_, ref: ForwardedRef<HTMLDivElement>) {
     const ulRef = useRef<HTMLUListElement>(null);
-
-    const { ref: inViewRef, inView } = useInView({
-      root: (ref as React.RefObject<HTMLDivElement>)?.current,
-      threshold: 1,
-    });
-
-    useEffect(() => {
-      const divEl = (ref as React.RefObject<HTMLDivElement>)?.current;
-      const ulEl = ulRef?.current;
-
-      if (!divEl || !ulEl) {
-        return;
-      }
-
-      if (
-        inView &&
-        hasNextPage &&
-        !isFetchingNextPage &&
-        ulEl.scrollHeight <= divEl.clientHeight
-      ) {
-        fetchNextPage();
-      }
-    }, [inView, hasNextPage, isFetchingNextPage]);
-
-    useEffect(() => {
-      const divEl = (ref as React.RefObject<HTMLDivElement>)?.current;
-      const ulEl = ulRef?.current;
-
-      if (!divEl || !ulEl) {
-        return;
-      }
-
-      if (inView && hasNextPage && ulEl.scrollHeight > divEl.clientHeight) {
-        fetchNextPage();
-      }
-    }, [inView, hasNextPage]);
+    const {
+      query: { data, isError, error, hasNextPage },
+      inViewRef,
+    } = useInfiniteGoals(ref, ulRef);
 
     if (isError) {
       return <p>에러 발생: {(error as Error).message}</p>;

--- a/src/views/layouts/molecules/TabSideMenuList.tsx
+++ b/src/views/layouts/molecules/TabSideMenuList.tsx
@@ -6,12 +6,12 @@ import { cn } from "@/utils/cn";
 import TabSideMenuItem from "../atoms/TabSideMenuItem";
 
 export default memo(
-  forwardRef(function TabSideMenuList(_, ref: ForwardedRef<HTMLDivElement>) {
-    const ulRef = useRef<HTMLUListElement>(null);
+  forwardRef(function TabSideMenuList(_, ref: ForwardedRef<HTMLUListElement>) {
+    const containerRef = useRef<HTMLDivElement>(null);
     const {
       query: { data, isError, error, hasNextPage },
       inViewRef,
-    } = useInfiniteGoals(ref, ulRef);
+    } = useInfiniteGoals(containerRef, ref);
 
     if (isError) {
       return <p>에러 발생: {(error as Error).message}</p>;
@@ -24,9 +24,9 @@ export default memo(
           hasNextPage &&
             "after:absolute after:inset-x-0 after:bottom-0 after:h-1/3 after:max-h-[80px] after:bg-[linear-gradient(180deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.6)_57%,rgba(255,255,255,0.8)_100%)]",
         )}
-        ref={ref}
+        ref={containerRef}
       >
-        <ul className="min-h-0 flex-1 overflow-auto" ref={ulRef}>
+        <ul className="min-h-0 flex-1 overflow-auto" ref={ref}>
           {data?.map((goal) => (
             <TabSideMenuItem key={goal.id} content={goal.title} />
           ))}

--- a/src/views/layouts/organisms/MenuGoal.tsx
+++ b/src/views/layouts/organisms/MenuGoal.tsx
@@ -1,7 +1,6 @@
 import { FormEventHandler, memo, useRef, useState } from "react";
 
 import { useCreateGoal } from "@/hooks/goal/useCreateGoal";
-import { useFetchGoals } from "@/hooks/goal/useFetchGoals";
 import { cn } from "@/utils/cn";
 
 import AddButton from "../atoms/AddButton";
@@ -10,16 +9,19 @@ import GoalCreationForm from "../molecules/GoalCreationForm";
 import TabSideMenuList from "../molecules/TabSideMenuList";
 
 export default memo(function MenuGoal() {
-  const { data, isError, error } = useFetchGoals();
-  const mutation = useCreateGoal();
-
   const ref = useRef<HTMLDivElement>(null);
+  const mutation = useCreateGoal({
+    onSuccess: () => {
+      ref?.current?.scrollTo({
+        top: 0,
+      });
+    },
+  });
 
   const [showForm, setShowForm] = useState(false);
 
   const handleShowForm = () => {
     setShowForm(true);
-    ref.current?.scrollTo(0, ref.current?.scrollHeight);
   };
 
   const handleSubmit: FormEventHandler = (e) => {
@@ -49,14 +51,8 @@ export default memo(function MenuGoal() {
           </AddButton>
         </div>
         <div className="flex min-h-0 flex-1 flex-col gap-6">
-          {!isError ? (
-            <div className="flex-1 overflow-auto" ref={ref}>
-              <TabSideMenuList items={data?.goals || []} />
-              <GoalCreationForm onSubmit={handleSubmit} isVisible={showForm} />
-            </div>
-          ) : (
-            <p>에러 발생: {(error as Error).message}</p>
-          )}
+          <TabSideMenuList ref={ref} />
+          {showForm && <GoalCreationForm onSubmit={handleSubmit} />}
           <AddButton
             outline
             onClick={handleShowForm}

--- a/src/views/layouts/organisms/MenuGoal.tsx
+++ b/src/views/layouts/organisms/MenuGoal.tsx
@@ -9,11 +9,12 @@ import GoalCreationForm from "../molecules/GoalCreationForm";
 import TabSideMenuList from "../molecules/TabSideMenuList";
 
 export default memo(function MenuGoal() {
-  const ref = useRef<HTMLDivElement>(null);
+  const ulRef = useRef<HTMLUListElement>(null);
   const mutation = useCreateGoal({
     onSuccess: () => {
-      ref?.current?.scrollTo({
+      ulRef?.current?.scrollTo({
         top: 0,
+        behavior: "smooth",
       });
     },
   });
@@ -51,7 +52,7 @@ export default memo(function MenuGoal() {
           </AddButton>
         </div>
         <div className="flex min-h-0 flex-1 flex-col gap-6">
-          <TabSideMenuList ref={ref} />
+          <TabSideMenuList ref={ulRef} />
           {showForm && <GoalCreationForm onSubmit={handleSubmit} />}
           <AddButton
             outline


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-114)
  
<br/>

## 📗 작업 내용

- 목표 데이터 가져오기 api 요청을 하위 컴포넌트로 이동(TabSideMenuList)
- 목표 추가 api 추가적인 콜백 수행 처리 추가(useCreateGoal - onSuccess, onError) 및 쿼리 데이터 무한 스크롤에 맞춰 수정
- 목표 데이터 무한 스크롤 가져오기 hooks 추가


<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


