### PR TITLE
feat(TODO-136): 날짜 포맷 변환 함수 구현

### DIFF
--- a/src/utils/formatDate/formatDate.test.ts
+++ b/src/utils/formatDate/formatDate.test.ts
@@ -1,0 +1,43 @@
+import { formatDate } from "./formatDate";
+
+describe("formatDate 함수 테스트", () => {
+  test("ISO 8601 형식의 날짜 문자열을 기본 포맷(YYYY. MM. DD)으로 반환", () => {
+    expect(formatDate("2025-04-29T06:15:59.808Z")).toBe("2025. 04. 29");
+  });
+
+  test("Date 객체를 입력하면 기본 포맷(YYYY. MM. DD)으로 변환", () => {
+    const date = new Date(2025, 3, 29);
+    expect(formatDate(date)).toBe("2025. 04. 29");
+  });
+
+  test("타임스탬프(ms) 입력 시 기본 포맷(YYYY. MM. DD)으로 변환", () => {
+    const timestamp = new Date(2025, 3, 29).getTime();
+    expect(formatDate(timestamp)).toBe("2025. 04. 29");
+  });
+
+  test("문자열 형식(YYYY-MM-DD)의 날짜를 입력하면 기본 포맷(YYYY. MM. DD)으로 변환", () => {
+    expect(formatDate("2025-04-29")).toBe("2025. 04. 29");
+  });
+
+  test("MM/DD/YYYY 포맷으로 날짜를 변환", () => {
+    const date = new Date(2025, 3, 29);
+    expect(formatDate(date, "MM/DD/YYYY")).toBe("04/29/2025");
+  });
+
+  test("DD-MM-YYYY 포맷으로 날짜를 변환", () => {
+    const date = new Date(2025, 3, 29);
+    expect(formatDate(date, "DD-MM-YYYY")).toBe("29-04-2025");
+  });
+
+  test("유효하지 않은 날짜 문자열을 입력하면 예외를 발생", () => {
+    expect(() => formatDate("invalid-date")).toThrow(
+      "유효하지 않은 날짜 형식입니다.",
+    );
+  });
+
+  test("숫자 범위를 초과하는 타임스탬프를 입력하면 예외를 발생", () => {
+    expect(() => formatDate(9999999999999999)).toThrow(
+      "유효하지 않은 날짜 형식입니다.",
+    );
+  });
+});

--- a/src/utils/formatDate/formatDate.ts
+++ b/src/utils/formatDate/formatDate.ts
@@ -1,0 +1,35 @@
+// format 인자를 넣지 않으면 YYYY. MM. DD 형식이 기본으로 적용
+export function formatDate(
+  inputDate: Date | number | string,
+  format: string = "YYYY. MM. DD",
+): string {
+  let date: Date;
+
+  // 입력이 Date 객체라면 그대로 사용
+  if (inputDate instanceof Date) {
+    date = inputDate;
+  }
+  // 입력이 숫자(timestamp)라면 Date 객체로 변환
+  else if (typeof inputDate === "number") {
+    date = new Date(inputDate);
+  }
+  // 입력이 문자열이라면 Date 객체로 변환
+  else if (typeof inputDate === "string") {
+    date = new Date(inputDate);
+  } else {
+    throw new Error("유효하지 않은 날짜 형식입니다.");
+  }
+
+  // 유효한 날짜인지 확인
+  if (isNaN(date.getTime())) {
+    throw new Error("유효하지 않은 날짜 형식입니다.");
+  }
+
+  // 연, 월, 일 가져오기
+  const year: string = date.getFullYear().toString();
+  const month: string = String(date.getMonth() + 1).padStart(2, "0");
+  const day: string = String(date.getDate()).padStart(2, "0");
+
+  // 포맷에 따라 변환
+  return format.replace("YYYY", year).replace("MM", month).replace("DD", day);
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-136)
  
<br/>

## 📗 작업 내용

- 서버에서 `ISO 8601` 형식의 날짜 포맷을 반환해주어서 포매터가 필요할 것 같아 구현하였습니다.
- 기본적으로 `YYYY. MM. DD` 형식을 사용하며, 원하는 형식으로 변경할 수도 있습니다.

###  사용예시
``` typescript
formatDate(new Date()); 
// "2025. 02. 19" (현재 날짜 기준)

formatDate(1708320000000); 
// "2024. 02. 19" (Timestamp 입력)

formatDate("2024-05-15", "YYYY/MM/DD"); 
// "2024/05/15" (다른 포맷 적용)

formatDate("2024-12-01", "MM-DD-YYYY"); 
// "12-01-2024" (월-일-연도 형식)

formatDate("2025-04-29T06:15:59.808Z"); 
// "2025. 04. 29" (ISO 8601 입력)


````

### 테스트 완료

![image](https://github.com/user-attachments/assets/22c7d3c1-a2b6-4aa0-8e92-feb6be9d9488)



<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


