### PR TITLE
feat(TODO-66): 로그인/회원가입 유효성 체크 기능 구현

### DIFF
--- a/src/hooks/auth/useSign.ts
+++ b/src/hooks/auth/useSign.ts
@@ -10,11 +10,7 @@ interface FormData extends UserCreateRequstDto {
   confirmPassword: string;
 }
 
-interface UseLoginProps {
-  redirect?: string;
-}
-
-function useLogin({ redirect = "/dashboard" }: UseLoginProps) {
+function useLogin() {
   const router = useRouter();
   const methods = useFormContext();
   return useMutation({
@@ -23,7 +19,7 @@ function useLogin({ redirect = "/dashboard" }: UseLoginProps) {
       return response.data;
     },
     onSuccess: () => {
-      router.push(redirect);
+      router.push("/dashboard");
     },
     onError: (error) => {
       if (isAxiosError(error)) {

--- a/src/hooks/auth/useSign.ts
+++ b/src/hooks/auth/useSign.ts
@@ -14,7 +14,7 @@ interface UseLoginProps {
   redirect?: string;
 }
 
-export function useLogin({ redirect = "/dashboard" }: UseLoginProps) {
+function useLogin({ redirect = "/dashboard" }: UseLoginProps) {
   const router = useRouter();
   const methods = useFormContext();
   return useMutation({
@@ -40,7 +40,7 @@ export function useLogin({ redirect = "/dashboard" }: UseLoginProps) {
   });
 }
 
-export function useSignUp() {
+function useSignUp() {
   const methods = useFormContext();
   return useMutation({
     mutationFn: async (params: FormData) => {

--- a/src/hooks/auth/useSign.ts
+++ b/src/hooks/auth/useSign.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 
 import instance from "@/apis/apiClient";
-import { LoginBodyDto, UserCreateRequstDto } from "@/types/types";
+import { UserCreateRequstDto } from "@/types/types";
 
 interface FormData extends UserCreateRequstDto {
   confirmPassword: string;
@@ -11,7 +11,7 @@ interface FormData extends UserCreateRequstDto {
 export function useLogin() {
   const router = useRouter();
   return useMutation({
-    mutationFn: async (params: LoginBodyDto) => {
+    mutationFn: async (params: FormData) => {
       const response = await instance.post("/auth/login", params);
       return response.data;
     },
@@ -27,14 +27,6 @@ export function useSignUp() {
     mutationFn: async (params: FormData) => {
       const response = await instance.post("/user", params);
       return response.data;
-    },
-    onMutate: async (params) => {
-      //프론트에서 검증하는 부분
-      if (params.confirmPassword !== params.password) {
-        return Promise.reject({
-          message: "두 비밀번호가 일치하지 않습니다.",
-        });
-      }
     },
   });
 }

--- a/src/hooks/auth/useSign.ts
+++ b/src/hooks/auth/useSign.ts
@@ -1,5 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { useRouter } from "next/router";
+import { useFormContext } from "react-hook-form";
 
 import instance from "@/apis/apiClient";
 import { UserCreateRequstDto } from "@/types/types";
@@ -8,25 +10,61 @@ interface FormData extends UserCreateRequstDto {
   confirmPassword: string;
 }
 
-export function useLogin() {
+interface UseLoginProps {
+  redirect?: string;
+}
+
+export function useLogin({ redirect = "/dashboard" }: UseLoginProps) {
   const router = useRouter();
+  const methods = useFormContext();
   return useMutation({
     mutationFn: async (params: FormData) => {
       const response = await instance.post("/auth/login", params);
       return response.data;
     },
     onSuccess: () => {
-      //로그인 성공 시 대시보드로 이동
-      router.push("/dashboard");
+      router.push(redirect);
+    },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        if (error.message.includes("이메일"))
+          methods.setError("email", { type: "server", message: error.message });
+        else if (error.message.includes("비밀번호")) {
+          methods.setError("password", {
+            type: "server",
+            message: error.message,
+          });
+        }
+      }
     },
   });
 }
 
 export function useSignUp() {
+  const methods = useFormContext();
   return useMutation({
     mutationFn: async (params: FormData) => {
       const response = await instance.post("/user", params);
       return response.data;
     },
+    onError: (error) => {
+      if (isAxiosError(error)) {
+        if (error.message.includes("이메일"))
+          methods.setError("email", { type: "server", message: error.message });
+        else if (error.message.includes("비밀번호")) {
+          methods.setError("password", {
+            type: "server",
+            message: error.message,
+          });
+        }
+      }
+    },
   });
 }
+
+const useSign = {
+  login: useLogin,
+  signup: useSignUp,
+};
+
+export default useSign;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import { LOGIN } from "@/views/sign/fieldSet";
 import Form from "@/views/sign/Form";
 import logo from "@public/img_logo.png";
 
@@ -16,7 +15,7 @@ export default function Login() {
         height={89}
       />
       <Form>
-        <Form.InnerForm field={LOGIN} path="login" />
+        <Form.InnerForm />
       </Form>
       <p className="mt-10 text-center font-normal">
         슬리드 투두가 처음이신가요?

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -8,7 +8,7 @@ import Form from "@/views/sign/Form";
 import logo from "@public/img_logo.png";
 
 export default function Login() {
-  const { mutate, isError, error } = useLogin();
+  const login = useLogin();
 
   return (
     <div className="mt-12 sm:mt-16 md:mt-30">
@@ -19,14 +19,15 @@ export default function Login() {
         width={270}
         height={89}
       />
-      <Form onSubmit={mutate} field={LOGIN}>
-        <Button type="submit" className="mt-10">
+      <Form hooks={login} field={LOGIN}>
+        <Button
+          onClick={(e) => e.currentTarget.blur()}
+          type="submit"
+          className="mt-10"
+        >
           로그인하기
         </Button>
       </Form>
-      <div className="mt-5 min-h-[24px] text-center">
-        {isError && error.message}
-      </div>
       <p className="mt-10 text-center font-normal">
         슬리드 투두가 처음이신가요?
         <Link

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,15 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import Button from "@/components/atoms/button/Button";
-import { useLogin } from "@/hooks/auth/useSign";
 import { LOGIN } from "@/views/sign/fieldSet";
 import Form from "@/views/sign/Form";
 import logo from "@public/img_logo.png";
 
 export default function Login() {
-  const login = useLogin();
-
   return (
     <div className="mt-12 sm:mt-16 md:mt-30">
       <Image
@@ -19,14 +15,8 @@ export default function Login() {
         width={270}
         height={89}
       />
-      <Form hooks={login} field={LOGIN}>
-        <Button
-          onClick={(e) => e.currentTarget.blur()}
-          type="submit"
-          className="mt-10"
-        >
-          로그인하기
-        </Button>
+      <Form>
+        <Form.InnerForm field={LOGIN} path="login" />
       </Form>
       <p className="mt-10 text-center font-normal">
         슬리드 투두가 처음이신가요?

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -5,11 +5,10 @@ import Button from "@/components/atoms/button/Button";
 import { useSignUp } from "@/hooks/auth/useSign";
 import { SIGNUP } from "@/views/sign/fieldSet";
 import Form from "@/views/sign/Form";
-import Modal from "@/views/sign/Modal";
 import logo from "@public/img_logo.png";
 
 export default function Signup() {
-  const { mutate, isError, error, isSuccess } = useSignUp();
+  const signup = useSignUp();
 
   return (
     <div className="mt-12 sm:mt-16 md:mt-30">
@@ -20,14 +19,15 @@ export default function Signup() {
         width={270}
         height={89}
       />
-      <Form onSubmit={mutate} field={SIGNUP}>
-        <Button type="submit" className="mt-10">
+      <Form hooks={signup} field={SIGNUP}>
+        <Button
+          onClick={(e) => e.currentTarget.blur()}
+          type="submit"
+          className="mt-10"
+        >
           회원가입하기
         </Button>
       </Form>
-      <div className="mt-5 min-h-[24px] text-center">
-        {isError && error.message}
-      </div>
       <p className="mt-10 text-center font-normal">
         이미 회원이신가요?
         <Link
@@ -37,7 +37,6 @@ export default function Signup() {
           로그인
         </Link>
       </p>
-      {isSuccess && <Modal />}
     </div>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,15 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import Button from "@/components/atoms/button/Button";
-import { useSignUp } from "@/hooks/auth/useSign";
 import { SIGNUP } from "@/views/sign/fieldSet";
 import Form from "@/views/sign/Form";
 import logo from "@public/img_logo.png";
 
 export default function Signup() {
-  const signup = useSignUp();
-
   return (
     <div className="mt-12 sm:mt-16 md:mt-30">
       <Image
@@ -19,14 +15,8 @@ export default function Signup() {
         width={270}
         height={89}
       />
-      <Form hooks={signup} field={SIGNUP}>
-        <Button
-          onClick={(e) => e.currentTarget.blur()}
-          type="submit"
-          className="mt-10"
-        >
-          회원가입하기
-        </Button>
+      <Form>
+        <Form.InnerForm field={SIGNUP} path="login" />
       </Form>
       <p className="mt-10 text-center font-normal">
         이미 회원이신가요?

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import { SIGNUP } from "@/views/sign/fieldSet";
 import Form from "@/views/sign/Form";
 import logo from "@public/img_logo.png";
 
@@ -16,7 +15,7 @@ export default function Signup() {
         height={89}
       />
       <Form>
-        <Form.InnerForm field={SIGNUP} path="login" />
+        <Form.InnerForm />
       </Form>
       <p className="mt-10 text-center font-normal">
         이미 회원이신가요?

--- a/src/types/Sign.ts
+++ b/src/types/Sign.ts
@@ -1,7 +1,11 @@
+import { type RegisterOptions } from "react-hook-form";
+
+type InputType = HTMLInputElement["type"];
+
 export interface SignField {
   name: string;
-  type: string;
+  type: InputType;
   label?: string;
   placeholder?: string;
-  rules?: RegExp;
+  rules?: RegisterOptions;
 }

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { usePathname } from "next/navigation";
 import { ReactNode, useRef } from "react";
 import {

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -1,5 +1,5 @@
 import { usePathname } from "next/navigation";
-import { ReactNode, useRef } from "react";
+import { ReactNode } from "react";
 import {
   FormProvider,
   type SubmitHandler,
@@ -33,34 +33,13 @@ const Form = ({ children }: FormProps) => {
 
 const InnerForm = () => {
   const methods = useFormContext<FormData>();
-  const timeoutIdRef = useRef<number | null>(null);
   const pathname = usePathname();
   const isLoginPage = pathname === "/login" ? true : false;
   const hooks = isLoginPage ? useSign.login({}) : useSign.signup();
   const field = isLoginPage ? LOGIN : SIGNUP;
 
-  const handleRequest: SubmitHandler<FormData> = async (
-    formData: FormData,
-    event,
-  ) => {
-    if (event?.type === "submit") {
-      if (timeoutIdRef.current) {
-        clearTimeout(timeoutIdRef.current);
-      }
-      hooks.mutate(formData);
-    }
-  };
-
-  const handleFocus: React.FocusEventHandler = (event) => {
-    if (timeoutIdRef.current) {
-      clearTimeout(timeoutIdRef.current);
-    }
-    const { name } = event.target as HTMLInputElement;
-    timeoutIdRef.current = window.setTimeout(() => {
-      if (!!methods.getValues(name as keyof FormData) === false) {
-        methods.handleSubmit(handleRequest)();
-      }
-    }, 1000);
+  const handleRequest: SubmitHandler<FormData> = async (formData: FormData) => {
+    hooks.mutate(formData);
   };
 
   return (
@@ -68,8 +47,6 @@ const InnerForm = () => {
       <form
         onSubmit={methods.handleSubmit(handleRequest)}
         className="mx-4 mt-10 sm:mx-13 md:mx-160"
-        onBlur={methods.handleSubmit(handleRequest)}
-        onFocus={handleFocus}
       >
         {field.map((item) => (
           <Input

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -59,9 +59,13 @@ const Form = ({ children, field, hooks }: FormProps) => {
     }
   };
 
-  const handleFocus = () => {
+  const handleFocus: React.FocusEventHandler = (event) => {
+    const { name } = event.target as HTMLInputElement;
+
     setTimeout(() => {
-      methods.handleSubmit(handleRequest);
+      if (!!methods.getValues(name as keyof FormData) === false) {
+        methods.handleSubmit(handleRequest)();
+      }
     }, 1000);
   };
 

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -35,7 +35,7 @@ const InnerForm = () => {
   const methods = useFormContext<FormData>();
   const pathname = usePathname();
   const isLoginPage = pathname === "/login" ? true : false;
-  const hooks = isLoginPage ? useSign.login({}) : useSign.signup();
+  const hooks = isLoginPage ? useSign.login() : useSign.signup();
   const field = isLoginPage ? LOGIN : SIGNUP;
 
   const handleRequest: SubmitHandler<FormData> = async (formData: FormData) => {

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -55,18 +55,14 @@ const InnerForm = ({ field, path }: InnerFormProps) => {
     }
   };
 
-  const startTimeout = (name: string) => {
+  const handleFocus: React.FocusEventHandler = (event) => {
+    clearTimeout(timeoutId);
+    const { name } = event.target as HTMLInputElement;
     timeoutId = window.setTimeout(() => {
       if (!!methods.getValues(name as keyof FormData) === false) {
         methods.handleSubmit(handleRequest)();
       }
     }, 1000);
-  };
-
-  const handleFocus: React.FocusEventHandler = (event) => {
-    clearTimeout(timeoutId);
-    const { name } = event.target as HTMLInputElement;
-    startTimeout(name);
   };
 
   return (

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -1,36 +1,78 @@
+import { UseMutationResult } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { ReactNode } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, type SubmitHandler, useForm } from "react-hook-form";
 
 import { SignField } from "@/types/Sign";
 import { UserCreateRequstDto } from "@/types/types";
 
 import Input from "./Input";
+
 interface FormData extends UserCreateRequstDto {
   confirmPassword: string;
 }
 
-interface FormProps<T extends FormData> {
+interface FormProps {
   children: ReactNode;
   field: SignField[];
-  onSubmit: (data: T) => void;
+  hooks: UseMutationResult<unknown, Error, FormData>;
 }
 
-const Form = <T extends FormData>({
-  children,
-  field,
-  onSubmit,
-}: FormProps<T>) => {
-  const hookForm = useForm<T>();
-  const handleRequest = async (formData: T) => {
-    onSubmit(formData);
+const Form = ({ children, field, hooks }: FormProps) => {
+  const methods = useForm<FormData>({
+    shouldFocusError: false,
+  });
+
+  const handleRequest: SubmitHandler<FormData> = async (
+    formData: FormData,
+    event,
+  ) => {
+    try {
+      if ("confirmPassword" in formData) {
+        if (formData.confirmPassword !== formData.password) {
+          methods.setError("confirmPassword", {
+            type: "manual",
+            message: "비밀번호가 일치하지 않습니다.",
+          });
+          return;
+        }
+      }
+      //버튼이 클릭된 경우 서버요청 및 에러처리
+      if (event?.type === "submit") {
+        await hooks.mutateAsync(formData);
+      }
+    } catch (e) {
+      //axios error
+      if (isAxiosError(e)) {
+        if (e.message.includes("이메일"))
+          methods.setError("email", { type: "server", message: e.message });
+        else if (e.message.includes("비밀번호")) {
+          methods.setError("password", {
+            type: "server",
+            message: e.message,
+          });
+        }
+        //unknown error
+      } else {
+        alert("알 수 없는 에러가 발생했습니다.");
+      }
+    }
+  };
+
+  const handleFocus = () => {
+    setTimeout(() => {
+      methods.handleSubmit(handleRequest);
+    }, 1000);
   };
 
   return (
     <>
-      <FormProvider {...hookForm}>
+      <FormProvider {...methods}>
         <form
-          onSubmit={hookForm.handleSubmit(handleRequest)}
+          onSubmit={methods.handleSubmit(handleRequest)}
           className="mx-4 mt-10 sm:mx-13 md:mx-160"
+          onBlur={methods.handleSubmit(handleRequest)}
+          onFocus={handleFocus}
         >
           {field.map((item) => (
             <Input
@@ -39,6 +81,7 @@ const Form = <T extends FormData>({
               name={item.name}
               type={item.type}
               placeholder={item.placeholder}
+              rules={item.rules}
             >
               <Input.Label />
               <Input.Input />

--- a/src/views/sign/Form.tsx
+++ b/src/views/sign/Form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { ReactNode } from "react";
 import {
   FormProvider,
@@ -10,9 +11,9 @@ import {
 
 import Button from "@/components/atoms/button/Button";
 import useSign from "@/hooks/auth/useSign";
-import { SignField } from "@/types/Sign";
 import { UserCreateRequstDto } from "@/types/types";
 
+import { LOGIN, SIGNUP } from "./fieldSet";
 import Input from "./Input";
 import Modal from "./Modal";
 
@@ -24,11 +25,6 @@ interface FormProps {
   children: ReactNode;
 }
 
-interface InnerFormProps {
-  field: SignField[];
-  path: string;
-}
-
 const Form = ({ children }: FormProps) => {
   const methods = useForm<FormData>({
     shouldFocusError: false,
@@ -37,10 +33,12 @@ const Form = ({ children }: FormProps) => {
   return <FormProvider {...methods}>{children}</FormProvider>;
 };
 
-const InnerForm = ({ field, path }: InnerFormProps) => {
-  const isLoginPage = path === "login" ? true : false;
+const InnerForm = () => {
+  const pathname = usePathname();
+  const isLoginPage = pathname === "/login" ? true : false;
+  const hooks = isLoginPage ? useSign.login({}) : useSign.signup();
   const methods = useFormContext<FormData>();
-  const hooks = path === "login" ? useSign.login({}) : useSign.signup();
+  const field = isLoginPage ? LOGIN : SIGNUP;
   let timeoutId: number;
 
   const handleRequest: SubmitHandler<FormData> = async (
@@ -50,8 +48,6 @@ const InnerForm = ({ field, path }: InnerFormProps) => {
     clearTimeout(timeoutId);
     if (event?.type === "submit") {
       hooks.mutate(formData);
-    } else {
-      return;
     }
   };
 

--- a/src/views/sign/Input.stories.tsx
+++ b/src/views/sign/Input.stories.tsx
@@ -1,0 +1,59 @@
+import { FormProvider, useForm } from "react-hook-form";
+
+import Button from "@/components/atoms/button/Button";
+
+import Input from "./Input";
+import type { Meta, StoryFn } from "@storybook/react";
+
+const story: Meta<typeof Input> = {
+  component: Input,
+  title: "views/sign/Input",
+  tags: ["autodocs"],
+};
+
+const Template: StoryFn<typeof Input> = (args) => {
+  const methods = useForm();
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(() => {})}>
+        <Input {...args}>
+          <Input.Label />
+          <Input.Input />
+        </Input>
+        <Button
+          onClick={(e) => e.currentTarget.blur()}
+          className="mt-10"
+          type="submit"
+        >
+          클릭하기
+        </Button>
+      </form>
+    </FormProvider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  name: "name",
+  label: "your name",
+  type: "text",
+  placeholder: "너의 이름은?",
+};
+
+export const Password = Template.bind({});
+Password.args = {
+  name: "password",
+  label: "비밀번호",
+  type: "password",
+  placeholder: "입력하면 해킹 당할 수도?!",
+  rules: {
+    required: "입력필수",
+    minLength: {
+      value: 8,
+      message: "8자 이상 입력해주세요",
+    },
+  },
+};
+
+export default story;

--- a/src/views/sign/Input.tsx
+++ b/src/views/sign/Input.tsx
@@ -7,11 +7,16 @@ import Input from "@/components/atoms/input/Input";
 import { SignField } from "@/types/Sign";
 import Off from "@public/visibility_off.png";
 
-interface InputComponentProps extends SignField {
-  children: React.ReactNode;
+interface InputField extends SignField {
+  disabled?: boolean;
 }
 
-const InputContext = createContext<SignField | null>(null);
+interface InputComponentProps extends SignField {
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+const InputContext = createContext<InputField | null>(null);
 
 export const InputComponent = ({
   name,
@@ -20,9 +25,12 @@ export const InputComponent = ({
   children,
   placeholder,
   rules,
+  disabled,
 }: InputComponentProps) => {
   return (
-    <InputContext.Provider value={{ name, type, label, placeholder, rules }}>
+    <InputContext.Provider
+      value={{ name, type, label, placeholder, rules, disabled }}
+    >
       <div className="mt-6 flex flex-col first:mt-0">{children}</div>
     </InputContext.Provider>
   );

--- a/src/views/sign/Input.tsx
+++ b/src/views/sign/Input.tsx
@@ -54,13 +54,19 @@ const InputContainer = () => {
   const { name, type, placeholder, rules } = context;
   const [inputType, setInputType] = useState(type);
 
+  const validateField = async () => {
+    const isValid = await trigger(name);
+
+    if (isValid) {
+      clearErrors(name);
+    }
+  };
+
   const handleFocus = async () => {
     if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
     clearErrors(name);
     timeoutRef.current = window.setTimeout(async () => {
-      if (await trigger(name)) {
-        clearErrors(name);
-      }
+      await validateField();
     }, 1000);
   };
 
@@ -68,16 +74,11 @@ const InputContainer = () => {
     e: React.ChangeEvent<HTMLInputElement> | undefined,
   ) => {
     setValue(name, e?.target.value);
-    if (await trigger(name)) {
-      clearErrors(name);
-    }
+    await validateField();
   };
 
   const handleBlur = async () => {
-    if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
-    if (await trigger(name)) {
-      clearErrors(name);
-    }
+    await validateField();
   };
 
   return (

--- a/src/views/sign/LoginPage.stories.tsx
+++ b/src/views/sign/LoginPage.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import Login from "@/pages/login";
+
+const queryClient = new QueryClient();
+
+const meta: Meta<typeof Login> = {
+  component: Login,
+  title: "pages/sign/loginPage",
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Default = {};

--- a/src/views/sign/Modal.stories.tsx
+++ b/src/views/sign/Modal.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta } from "@storybook/react";
+
+import Modal from "./Modal";
+
+const meta = {
+  component: Modal,
+  title: "views/sign/modal",
+  tags: ["autodocs"],
+};
+
+export const Default = {};
+
+export default meta;

--- a/src/views/sign/SignupPage.stories.tsx
+++ b/src/views/sign/SignupPage.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import Signup from "@/pages/signup";
+
+const queryClient = new QueryClient();
+
+const meta: Meta<typeof Signup> = {
+  component: Signup,
+  title: "pages/sign/signupPage",
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Default = {};

--- a/src/views/sign/fieldSet.ts
+++ b/src/views/sign/fieldSet.ts
@@ -8,6 +8,10 @@ const LOGIN: SignField[] = [
     placeholder: "이메일을 입력해주세요",
     rules: {
       required: "이메일을 입력해주세요",
+      pattern: {
+        value: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
+        message: "이메일 형식이 아닙니다",
+      },
     },
   },
   {
@@ -38,6 +42,10 @@ const SIGNUP: SignField[] = [
     placeholder: "이메일을 입력해주세요",
     rules: {
       required: "이메일을 입력해주세요",
+      pattern: {
+        value: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
+        message: "이메일 형식이 아닙니다",
+      },
     },
   },
   {

--- a/src/views/sign/fieldSet.ts
+++ b/src/views/sign/fieldSet.ts
@@ -6,12 +6,18 @@ const LOGIN: SignField[] = [
     name: "email",
     type: "text",
     placeholder: "이메일을 입력해주세요",
+    rules: {
+      required: "이메일을 입력해주세요",
+    },
   },
   {
     label: "비밀번호",
     name: "password",
     type: "password",
     placeholder: "비밀번호를 입력해주세요",
+    rules: {
+      required: "비밀번호를 입력해주세요",
+    },
   },
 ];
 
@@ -21,13 +27,40 @@ const SIGNUP: SignField[] = [
     name: "name",
     type: "text",
     placeholder: "이름을 입력해주세요",
+    rules: {
+      required: "이름을 입력해주세요",
+    },
   },
-  ...LOGIN,
+  {
+    label: "이메일",
+    name: "email",
+    type: "text",
+    placeholder: "이메일을 입력해주세요",
+    rules: {
+      required: "이메일을 입력해주세요",
+    },
+  },
+  {
+    label: "비밀번호",
+    name: "password",
+    type: "password",
+    placeholder: "비밀번호를 입력해주세요",
+    rules: {
+      required: "비밀번호를 입력해주세요",
+      minLength: {
+        value: 8,
+        message: "비밀번호는 8 자 이상 입력해주세요.",
+      },
+    },
+  },
   {
     label: "비밀번호 확인",
     name: "confirmPassword",
     type: "password",
     placeholder: "비밀번호 확인을 입력해주세요",
+    rules: {
+      required: "비밀번호 확인을 입력해주세요",
+    },
   },
 ];
 

--- a/src/views/sign/fieldSet.ts
+++ b/src/views/sign/fieldSet.ts
@@ -60,6 +60,8 @@ const SIGNUP: SignField[] = [
     placeholder: "비밀번호 확인을 입력해주세요",
     rules: {
       required: "비밀번호 확인을 입력해주세요",
+      validate: (value, formValues) =>
+        value === formValues.password || "비밀번호가 일치하지 않습니다.",
     },
   },
 ];


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-66)
  
<br/>

## 📗 작업 내용

- 로그인/회원가입에 유효성 검사 기능을 추가했습니다.
- pages/login, signup에 있던 프롭들을 Form에 넘겨주었습니다.
- 서버 유효성 체크는 useSign 훅에서 처리합니다.
- 스토리북 파일을 추가했습니다.


## 💬 리뷰 요구사항(선택)

- 유효성 체크를 이렇게 적용해도 괜찮을까요
