### PR TITLE
style(TODO-135): Sidebar 기본 open 상태 및 Button 컴포넌트 style 수정

### DIFF
--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center font-semibold rounded-[12px]",
+  "box-border inline-flex items-center justify-center font-semibold rounded-[12px]",
   {
     variants: {
       variant: {
@@ -30,10 +30,8 @@ const buttonVariants = cva(
   },
 );
 
-type ButtonElementProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   VariantProps<typeof buttonVariants>;
-
-type ButtonProps = ButtonElementProps;
 
 export default function Button({
   variant = "default",

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -10,16 +10,16 @@ import SidebarHeader from "../organisms/SidebarHeader";
 const TABLET_BREAKPOINT = 964;
 
 export default function Sidebar({ title }: { title: string }) {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleToggleSidebar = () => {
     setIsOpen((prev) => !prev);
   };
 
   useEffect(() => {
-    // 모바일이면 Sidebar를 닫음
-    if (window.innerWidth < TABLET_BREAKPOINT) {
-      setIsOpen(false);
+    // 기본 사이드 바 상태 지정 (모바일: 닫힘, PC/태블릿: 열림)
+    if (window.innerWidth >= TABLET_BREAKPOINT) {
+      setIsOpen(true);
     }
   }, []);
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-이슈번호)
  
<br/>

## 📗 작업 내용

- 사이드바에서의 isOpen 상태의 기본값을 변경했습니다
  - 모바일에서 빠르게 열렸다 닫히는 플리커 현상을 제거하기 위함
  - 태블릿 이상의 크기에서 닫힘 -> 열림이 애니메이션으로 자연스럽게 처리됨
- Button 컴포넌트에 box-sizing: border-box를 적용했습니다.
  - outline과 default의 크기가 border로 인해 다르기 때문


<br/>


## 💬 리뷰 요구사항(선택)

[PR #81](https://github.com/Quesddo/Client/pull/81) 과 동일하나 develop으로 merge 하여 main으로 다시 올립니다..

