### PR TITLE
feat(TODO-144): PageTItle 컴포넌트 추가 및 sidebar 내부에서 pathname에 따라 hidden 결정

### DIFF
--- a/src/components/atoms/page-title/PageTitle.stories.ts
+++ b/src/components/atoms/page-title/PageTitle.stories.ts
@@ -8,6 +8,9 @@ const meta = {
     title: {
       control: "text",
     },
+    isMobileFixed: {
+      control: "boolean",
+    },
   },
 } satisfies Meta<typeof PageTitle>;
 
@@ -18,5 +21,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     title: "대시보드",
+    isMobileFixed: false,
   },
 };

--- a/src/components/atoms/page-title/PageTitle.stories.ts
+++ b/src/components/atoms/page-title/PageTitle.stories.ts
@@ -1,0 +1,22 @@
+import PageTitle from "./PageTitle";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "Common/Atoms/PageTitle",
+  component: PageTitle,
+  argTypes: {
+    title: {
+      control: "text",
+    },
+  },
+} satisfies Meta<typeof PageTitle>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "대시보드",
+  },
+};

--- a/src/components/atoms/page-title/PageTitle.tsx
+++ b/src/components/atoms/page-title/PageTitle.tsx
@@ -14,7 +14,10 @@ export default function PageTitle({
 }: PageTitleProps) {
   return (
     <h1
-      className={cn("text-lg font-semibold text-slate-900", className)}
+      className={cn(
+        "text-base font-semibold text-slate-900 sm:text-lg",
+        className,
+      )}
       {...props}
     >
       {title}

--- a/src/components/atoms/page-title/PageTitle.tsx
+++ b/src/components/atoms/page-title/PageTitle.tsx
@@ -1,0 +1,23 @@
+import { HTMLAttributes } from "react";
+
+import { cn } from "@/utils/cn";
+
+interface PageTitleProps
+  extends Omit<HTMLAttributes<HTMLHeadingElement>, "children"> {
+  title: string;
+}
+
+export default function PageTitle({
+  title,
+  className,
+  ...props
+}: PageTitleProps) {
+  return (
+    <h1
+      className={cn("text-lg font-semibold text-slate-900", className)}
+      {...props}
+    >
+      {title}
+    </h1>
+  );
+}

--- a/src/components/atoms/page-title/PageTitle.tsx
+++ b/src/components/atoms/page-title/PageTitle.tsx
@@ -19,7 +19,7 @@ export default function PageTitle({
       className={cn(
         "text-base font-semibold text-slate-900 sm:text-lg",
         isMobileFixed &&
-          "fixed top-0 left-10 px-4 py-3 sm:static sm:px-0 sm:py-3",
+          "fixed top-0 right-0 left-10 px-4 py-3 sm:static sm:px-0 sm:py-3",
         className,
       )}
       {...props}

--- a/src/components/atoms/page-title/PageTitle.tsx
+++ b/src/components/atoms/page-title/PageTitle.tsx
@@ -4,11 +4,13 @@ import { cn } from "@/utils/cn";
 
 interface PageTitleProps
   extends Omit<HTMLAttributes<HTMLHeadingElement>, "children"> {
+  isMobileFixed?: boolean;
   title: string;
 }
 
 export default function PageTitle({
   title,
+  isMobileFixed,
   className,
   ...props
 }: PageTitleProps) {
@@ -16,6 +18,8 @@ export default function PageTitle({
     <h1
       className={cn(
         "text-base font-semibold text-slate-900 sm:text-lg",
+        isMobileFixed &&
+          "fixed top-0 left-10 px-4 py-3 sm:static sm:px-0 sm:py-3",
         className,
       )}
       {...props}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,23 +2,16 @@ import "@/styles/globals.css";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { useRouter } from "next/router";
-
 import Sidebar from "../views/layouts/template/Sidebar";
 import type { AppProps } from "next/app";
 
 const queryClient = new QueryClient();
 
-const TO_HIDE_PATH = ["/", "/login", "/signup"];
-
 export default function App({ Component, pageProps }: AppProps) {
-  const router = useRouter();
-  const isHidden = TO_HIDE_PATH.includes(router.pathname);
-
   return (
     <QueryClientProvider client={queryClient}>
       <div className="flex h-screen flex-col overflow-y-hidden sm:flex-row">
-        {!isHidden && <Sidebar />}
+        <Sidebar />
         <main className="flex-1 overflow-y-auto">
           <Component {...pageProps} />
         </main>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,23 +9,16 @@ import type { AppProps } from "next/app";
 
 const queryClient = new QueryClient();
 
-interface PageProps extends AppProps {
-  Component: AppProps["Component"] & {
-    headerContent?: string;
-  };
-}
+const TO_HIDE_PATH = ["/", "/login", "/signup"];
 
-const TO_HIDE_PATH = ["", "/", "/login", "/signup"];
-
-export default function App({ Component, pageProps }: PageProps) {
+export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isHidden = TO_HIDE_PATH.includes(router.pathname);
-  const headerContent = Component.headerContent || "";
 
   return (
     <QueryClientProvider client={queryClient}>
       <div className="flex h-screen flex-col overflow-y-hidden sm:flex-row">
-        {!isHidden && <Sidebar title={headerContent} />}
+        {!isHidden && <Sidebar />}
         <main className="flex-1 overflow-y-auto">
           <Component {...pageProps} />
         </main>

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -9,8 +9,8 @@ import SidebarHeader from "../organisms/SidebarHeader";
 
 const TABLET_BREAKPOINT = 964;
 
-export default function Sidebar({ title }: { title: string }) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Sidebar() {
+  const [isOpen, setIsOpen] = useState(true);
 
   const handleToggleSidebar = () => {
     setIsOpen((prev) => !prev);
@@ -31,7 +31,6 @@ export default function Sidebar({ title }: { title: string }) {
         <button onClick={handleToggleSidebar}>
           <img src="/icons/hamburger.png" width={24} height={24} alt="메뉴" />
         </button>
-        <h1 className="text-base font-semibold">{title}</h1>
       </header>
       <aside
         className={cn(

--- a/src/views/layouts/template/Sidebar.tsx
+++ b/src/views/layouts/template/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { cn } from "@/utils/cn";
@@ -8,8 +9,12 @@ import Profile from "@/views/layouts/organisms/Profile";
 import SidebarHeader from "../organisms/SidebarHeader";
 
 const TABLET_BREAKPOINT = 964;
+const TO_HIDE_PATH = ["/", "/login", "/signup"];
 
 export default function Sidebar() {
+  const pathname = usePathname();
+  const isHidden = TO_HIDE_PATH.includes(pathname);
+
   const [isOpen, setIsOpen] = useState(true);
 
   const handleToggleSidebar = () => {
@@ -24,48 +29,53 @@ export default function Sidebar() {
   }, []);
 
   return (
-    <>
-      <header
-        className={cn("flex gap-4 px-4 py-3 sm:hidden", isOpen && "hidden")}
-      >
-        <button onClick={handleToggleSidebar}>
-          <img src="/icons/hamburger.png" width={24} height={24} alt="메뉴" />
-        </button>
-      </header>
-      <aside
-        className={cn(
-          // mobile 스타일
-          "z-20 box-border flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex,width] ease-[cubic-bezier(0,0.36,0,0.84)]",
-          // tablet + pc 스타일
-          "sm:w-[280px] sm:flex-[0_0_280px] sm:border-r sm:pb-9",
-          // tablet:fixed 관련
-          "smd:relative sm:fixed sm:inset-y-0 sm:left-0",
-          !isOpen && "hidden sm:flex sm:w-[60px] sm:flex-[0_0_60px]",
-        )}
-      >
-        <SidebarHeader isOpen={isOpen} onToggleSidebar={handleToggleSidebar} />
-        <div
+    !isHidden && (
+      <>
+        <header
+          className={cn("flex gap-4 px-4 py-3 sm:hidden", isOpen && "hidden")}
+        >
+          <button onClick={handleToggleSidebar}>
+            <img src="/icons/hamburger.png" width={24} height={24} alt="메뉴" />
+          </button>
+        </header>
+        <aside
           className={cn(
-            "flex min-h-0 flex-col opacity-100 [&>*]:px-3 sm:[&>*]:px-6",
-            !isOpen ? "opacity-0" : "transition-[opacity] delay-[10ms]",
+            // mobile 스타일
+            "z-20 box-border flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex,width] ease-[cubic-bezier(0,0.36,0,0.84)]",
+            // tablet + pc 스타일
+            "sm:w-[280px] sm:flex-[0_0_280px] sm:border-r sm:pb-9",
+            // tablet:fixed 관련
+            "smd:relative sm:fixed sm:inset-y-0 sm:left-0",
+            !isOpen && "hidden sm:flex sm:w-[60px] sm:flex-[0_0_60px]",
           )}
         >
-          <Profile />
-          <MenuDashboard />
-          <MenuGoal />
-        </div>
-      </aside>
-      <div
-        className={cn(
-          // sm ~ smd 까지 fixed 된 공간 설정
-          "h-screen w-[60px]",
-          "smd:hidden hidden sm:block",
-          // backdrop
-          "after:fixed after:inset-0 after:z-10 after:bg-black/50 after:opacity-100 after:transition-[opacity] after:delay-[10ms]",
-          "smd:after:hidden after:hidden sm:after:block",
-          !isOpen && "after:opacity-0 sm:after:hidden",
-        )}
-      ></div>
-    </>
+          <SidebarHeader
+            isOpen={isOpen}
+            onToggleSidebar={handleToggleSidebar}
+          />
+          <div
+            className={cn(
+              "flex min-h-0 flex-col opacity-100 [&>*]:px-3 sm:[&>*]:px-6",
+              !isOpen ? "opacity-0" : "transition-[opacity] delay-[10ms]",
+            )}
+          >
+            <Profile />
+            <MenuDashboard />
+            <MenuGoal />
+          </div>
+        </aside>
+        <div
+          className={cn(
+            // sm ~ smd 까지 fixed 된 공간 설정
+            "h-screen w-[60px]",
+            "smd:hidden hidden sm:block",
+            // backdrop
+            "after:fixed after:inset-0 after:z-10 after:bg-black/50 after:opacity-100 after:transition-[opacity] after:delay-[10ms]",
+            "smd:after:hidden after:hidden sm:after:block",
+            !isOpen && "after:opacity-0 sm:after:hidden",
+          )}
+        ></div>
+      </>
+    )
   );
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-144)
  
<br/>

## 📗 작업 내용

- 페이지마다 필요한 Title을 컴포넌트화했습니다.
- 해당 컴포넌트의 `isMobileFixed` 속성을 통해 header에 둘지 여부를 선택할 수 있습니다.
  -  이에 따라 기존 `Component.headerContent` 으로 지정하는 부분은 제거했습니다.
- [new🌟] sidebar 내부에서 pathname에 따라 hidden 결정

<br/>


## 💬 리뷰 요구사항(선택)
- `isMobileFixed = false` (기본값) 

  <img width="157" alt="스크린샷 2025-02-21 오후 2 26 40" src="https://github.com/user-attachments/assets/b9cc30d3-3c4c-4e1a-859b-1cf410b42118" />

- `isMobileFixed = true`

  <img width="205" alt="스크린샷 2025-02-21 오후 2 26 14" src="https://github.com/user-attachments/assets/e3d7e17c-0659-42d6-a029-07b6cf76af7e" />

