### PR TITLE
feat(TODO-150): 인증레이어 구현

### DIFF
--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,8 +1,10 @@
-import type { AxiosError, AxiosInstance } from "axios";
 import axios from "axios";
 
 import { ErrorResponsePayload } from "@/types/types";
 import { tokenUtils } from "@/utils/tokenUtils";
+
+import refreshTokens from "./apiRefreshTokens";
+import type { AxiosError, AxiosInstance } from "axios";
 
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BACKEND_URL,
@@ -24,7 +26,7 @@ instance.interceptors.response.use(
   (error) => handleError(error),
 );
 
-const handleError = (error: AxiosError): Promise<never> => {
+const handleError = async (error: AxiosError): Promise<never> => {
   if (error.message.includes("Network Error")) {
     return Promise.reject(new Error("네트워크 오류가 발생했습니다."));
   }
@@ -46,6 +48,18 @@ const handleError = (error: AxiosError): Promise<never> => {
       errorMessages[error.response.status] ||
       data.message ||
       `오류가 발생했습니다. (코드: ${error.response.status})`;
+
+    if (data.message === "Unauthorized") {
+      try {
+        const accessToken = await refreshTokens();
+        if (accessToken) {
+          if (error.config) {
+            error.config.headers.Authorization = `Bearer ${accessToken}`;
+            return axios(error.config);
+          }
+        }
+      } catch {}
+    }
   }
 
   return Promise.reject(error);

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -2,6 +2,7 @@ import type { AxiosError, AxiosInstance } from "axios";
 import axios from "axios";
 
 import { ErrorResponsePayload } from "@/types/types";
+import { tokenUtils } from "@/utils/tokenUtils";
 
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BACKEND_URL,
@@ -11,6 +12,8 @@ const instance: AxiosInstance = axios.create({
 instance.interceptors.request.use(
   (config) => {
     // header 설정 코드
+    const accessToken = tokenUtils.getAccessToken();
+    if (accessToken) config.headers.Authorization = `Bearer ${accessToken}`;
     return config;
   },
   (error) => handleError(error),

--- a/src/apis/apiRefreshTokens.ts
+++ b/src/apis/apiRefreshTokens.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+
+import { tokenUtils } from "@/utils/tokenUtils";
+
+export default async function refreshTokens() {
+  try {
+    const refreshToken = tokenUtils.getRefreshToken();
+
+    if (!refreshToken) throw new Error("No refresh token");
+
+    const { data } = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_BACKEND_URL}/auth/tokens`,
+      undefined,
+      {
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      },
+    );
+    tokenUtils.setToken(data.accessToken, data.refreshToken);
+    return data.accessToken;
+  } catch {
+    tokenUtils.clearToken();
+  }
+}

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from "next/router";
+import { ReactNode, useEffect } from "react";
+
+import { useAuth } from "@/hooks/auth/useAuth";
+
+interface AuthGuardProps {
+  children: ReactNode;
+}
+
+const PUBLICPATH = ["/login", "/signup"];
+
+export default function AuthGuard({ children }: AuthGuardProps) {
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+  const isPublicPage = PUBLICPATH.includes(router.pathname);
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (!isAuthenticated && !isPublicPage) {
+        router.replace("/login");
+      } else if (isAuthenticated && isPublicPage) {
+        router.replace("/dashboard");
+      }
+    }
+  }, [isAuthenticated, router, isPublicPage, isLoading]);
+
+  if (isLoading) return <div>페이지 이동 중...</div>;
+
+  if (isAuthenticated && isPublicPage) return null;
+
+  if (isAuthenticated || isPublicPage) return <>{children}</>;
+}

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -15,12 +15,18 @@ export default function AuthGuard({ children }: AuthGuardProps) {
   const isPublicPage = PUBLICPATH.includes(router.pathname);
 
   useEffect(() => {
-    if (!isLoading) {
-      if (!isAuthenticated && !isPublicPage) {
-        router.replace("/login");
-      } else if (isAuthenticated && isPublicPage) {
-        router.replace("/dashboard");
-      }
+    if (isLoading) return;
+
+    if (router.pathname === "/") {
+      if (isAuthenticated) router.replace("/dashboard");
+      else router.replace("/login");
+      return;
+    }
+
+    if (!isAuthenticated && !isPublicPage) {
+      router.replace("/login");
+    } else if (isAuthenticated && isPublicPage) {
+      router.replace("/dashboard");
     }
   }, [isAuthenticated, router, isPublicPage, isLoading]);
 

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+
+import instance from "@/apis/apiClient";
+import { UserServiceResponseDto } from "@/types/types";
+
+const fetchUser = async (): Promise<UserServiceResponseDto> => {
+  const { data } = await instance.get("/user");
+  return data;
+};
+
+export const useAuth = () => {
+  const { data: user, isLoading } = useQuery({
+    queryKey: ["user"],
+    queryFn: fetchUser,
+    retry: false,
+    staleTime: 1000 * 60 * 60,
+  });
+
+  return {
+    isAuthenticated: !!user?.id,
+    isLoading,
+  };
+};

--- a/src/hooks/auth/useSign.ts
+++ b/src/hooks/auth/useSign.ts
@@ -5,6 +5,7 @@ import { useFormContext } from "react-hook-form";
 
 import instance from "@/apis/apiClient";
 import { UserCreateRequstDto } from "@/types/types";
+import { tokenUtils } from "@/utils/tokenUtils";
 
 interface FormData extends UserCreateRequstDto {
   confirmPassword: string;
@@ -18,7 +19,8 @@ function useLogin() {
       const response = await instance.post("/auth/login", params);
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
+      tokenUtils.setToken(data.accessToken, data.refreshToken);
       router.push("/dashboard");
     },
     onError: (error) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { useRouter } from "next/router";
 
+import AuthGuard from "@/components/AuthGuard";
+
 import Sidebar from "../views/layouts/template/Sidebar";
 import type { AppProps } from "next/app";
 
@@ -24,13 +26,15 @@ export default function App({ Component, pageProps }: PageProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="flex h-screen flex-col overflow-y-hidden sm:flex-row">
-        {!isHidden && <Sidebar title={headerContent} />}
-        <main className="flex-1 overflow-y-auto">
-          <Component {...pageProps} />
-        </main>
-      </div>
-      <div id="global-modal"></div>
+      <AuthGuard>
+        <div className="flex h-screen flex-col overflow-y-hidden sm:flex-row">
+          {!isHidden && <Sidebar title={headerContent} />}
+          <main className="flex-1 overflow-y-auto">
+            <Component {...pageProps} />
+          </main>
+        </div>
+        <div id="global-modal"></div>
+      </AuthGuard>
     </QueryClientProvider>
   );
 }

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -1,0 +1,12 @@
+export const tokenUtils = {
+  getAccessToken: () => localStorage.getItem("accessToken"),
+  getRefreshToken: () => localStorage.getItem("refreshToken"),
+  setToken: (accessToken: string, refreshToken: string) => {
+    localStorage.setItem("accessToken", accessToken);
+    localStorage.setItem("refreshToken", refreshToken);
+  },
+  clearToken: () => {
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+  },
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-150)
  
<br/>

## 📗 작업 내용

- 전역으로 사용되는 AuthGuard, 인증레이어 추가
- AuthGuard에서 useAuth 사용
- apiClient.ts에서 message의 값을 확인하여 토큰재발급


## 💬 리뷰 요구사항(선택)

- 플로우를 다음과 같이 진행했는데 괜찮을까용??
  - 비회원은 로그인과 회원가입 페이지만 접근가능, 나머지 접근 시 로그인으로 리다이렉트 됩니다.
  - 회원은 투두 기능페이지 접근가능하며 로그인, 회원가입 접근 시 대시보드로 리다이렉트 됩니다.



