### PR TITLE
feat(TODO-160): [노트모아보기 페이지]  노트 수정, 삭제 기능 구현 및 리팩토링

### DIFF
--- a/src/apis/note/deleteNote.ts
+++ b/src/apis/note/deleteNote.ts
@@ -1,0 +1,4 @@
+import instance from "../apiClient";
+
+export const deleteNote = async (noteId: number) =>
+  await instance.delete(`/notes/${noteId}`);

--- a/src/apis/note/fetchNotes.ts
+++ b/src/apis/note/fetchNotes.ts
@@ -1,0 +1,14 @@
+import { teamIdNotesGetParams } from "@/types/types";
+
+import instance from "../apiClient";
+
+const PAGE_SIZE = 6;
+
+export const fetchNotes = async (pageParam: number, goalId: number) => {
+  const params: teamIdNotesGetParams = {
+    goalId,
+    cursor: pageParam,
+    size: PAGE_SIZE,
+  };
+  return (await instance.get("notes", { params })).data;
+};

--- a/src/hooks/note/useDeleteNote.ts
+++ b/src/hooks/note/useDeleteNote.ts
@@ -1,0 +1,55 @@
+import {
+  InfiniteData,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { deleteNote } from "@/apis/note/deleteNote";
+import { TeamIdNotesGet200Response } from "@/types/types";
+
+export const useDeleteNote = (goalId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (noteId: number) => deleteNote(noteId),
+
+    onMutate: async (noteId: number) => {
+      await queryClient.cancelQueries({ queryKey: ["notes", goalId] });
+
+      // 이전 상태 저장
+      const previousNotes = queryClient.getQueryData<
+        TeamIdNotesGet200Response["notes"]
+      >(["notes", goalId]);
+
+      // 낙관적 업데이트
+      queryClient.setQueryData<InfiniteData<TeamIdNotesGet200Response>>(
+        ["notes", goalId],
+        (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            pages: oldData.pages.map((page) => ({
+              ...page,
+              notes: page.notes.filter((note) => note.id !== noteId),
+            })),
+          };
+        },
+      );
+
+      return { previousNotes };
+    },
+
+    // 에러 발생 시 롤백
+    onError: (error, noteId, context) => {
+      if (context?.previousNotes) {
+        queryClient.setQueryData(["notes", goalId], context.previousNotes);
+      }
+      alert(error.message);
+    },
+
+    // 최종적으로 데이터 갱신
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["notes", goalId] });
+    },
+  });
+};

--- a/src/hooks/note/useInfiniteNotes.ts
+++ b/src/hooks/note/useInfiniteNotes.ts
@@ -8,7 +8,11 @@ import { TeamIdNotesGet200Response, teamIdNotesGetParams } from "@/types/types";
 export const useInfiniteNotes = (goalId: number) => {
   const { ref: inViewRef, inView } = useInView();
 
-  const query = useInfiniteQuery<TeamIdNotesGet200Response>({
+  const query = useInfiniteQuery<
+    TeamIdNotesGet200Response,
+    Error,
+    TeamIdNotesGet200Response["notes"]
+  >({
     queryKey: ["notes", goalId],
     queryFn: async ({ pageParam }) => {
       const params: teamIdNotesGetParams = {
@@ -21,6 +25,7 @@ export const useInfiniteNotes = (goalId: number) => {
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: null,
     enabled: !!goalId,
+    select: ({ pages }) => pages.flatMap(({ notes }) => notes),
   });
 
   useEffect(() => {

--- a/src/hooks/note/useInfiniteNotes.ts
+++ b/src/hooks/note/useInfiniteNotes.ts
@@ -2,8 +2,8 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 
-import instance from "@/apis/apiClient";
-import { TeamIdNotesGet200Response, teamIdNotesGetParams } from "@/types/types";
+import { fetchNotes } from "@/apis/note/fetchNotes";
+import { TeamIdNotesGet200Response } from "@/types/types";
 
 export const useInfiniteNotes = (goalId: number) => {
   const { ref: inViewRef, inView } = useInView();
@@ -14,14 +14,7 @@ export const useInfiniteNotes = (goalId: number) => {
     TeamIdNotesGet200Response["notes"]
   >({
     queryKey: ["notes", goalId],
-    queryFn: async ({ pageParam }) => {
-      const params: teamIdNotesGetParams = {
-        goalId,
-        cursor: pageParam as number,
-        size: 5,
-      };
-      return (await instance.get("notes", { params })).data;
-    },
+    queryFn: ({ pageParam }) => fetchNotes(Number(pageParam), goalId),
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: null,
     enabled: !!goalId,

--- a/src/pages/goal/[goalId]/notes/index.tsx
+++ b/src/pages/goal/[goalId]/notes/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 
-import { useInfiniteNotes } from "@/hooks/notes/useInfiniteNotes";
+import { useInfiniteNotes } from "@/hooks/note/useInfiniteNotes";
+import EmptyNotes from "@/views/notes/empty-notes/EmptyNotes";
 import Goal from "@/views/notes/goal/Goal";
 import NoteList from "@/views/notes/note-list/NoteList";
 
@@ -8,15 +9,23 @@ export default function NotesPage() {
   const {
     query: { goalId },
   } = useRouter();
-  const { data, inViewRef } = useInfiniteNotes(Number(goalId));
+  const { data: notes, inViewRef } = useInfiniteNotes(Number(goalId));
+
+  const hasNotes = notes && notes.length > 0;
 
   return (
     <div className="min-h-screen bg-slate-100">
       <div className="flex max-w-[792px] flex-col gap-4 p-4 sm:pl-[84px] md:pl-[360px]">
         <h1 className="text-lg font-semibold text-slate-900">노트 모아보기</h1>
 
-        <Goal goal={data?.pages[0]?.notes[0]?.goal?.title} />
-        <NoteList data={data} inViewRef={inViewRef} />
+        {hasNotes ? (
+          <>
+            <Goal goal={notes[0]?.goal?.title} />
+            <NoteList notes={notes} inViewRef={inViewRef} />
+          </>
+        ) : (
+          <EmptyNotes />
+        )}
       </div>
     </div>
   );

--- a/src/pages/goal/[goalId]/notes/index.tsx
+++ b/src/pages/goal/[goalId]/notes/index.tsx
@@ -9,6 +9,7 @@ export default function NotesPage() {
   const {
     query: { goalId },
   } = useRouter();
+
   const { data: notes, inViewRef } = useInfiniteNotes(Number(goalId));
 
   const hasNotes = notes && notes.length > 0;

--- a/src/views/notes/card/Card.stories.tsx
+++ b/src/views/notes/card/Card.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof Card>;
 export const card: Story = {
   render: () => (
     <Card>
-      <Card.Header />
+      <Card.Header noteId={-1} />
       <Card.Body>
         <Card.Title>자바스크립트를 시작하기 전 준비물</Card.Title>
         <Card.Divider />

--- a/src/views/notes/card/Card.tsx
+++ b/src/views/notes/card/Card.tsx
@@ -1,17 +1,17 @@
 import Image from "next/image";
+import { useRouter } from "next/router";
 import { ReactNode, useState } from "react";
 
 import ActionDropdown from "@/components/atoms/action-dropdown/ActionDropdown";
 import Divider from "@/components/atoms/divider/Divider";
 import TodoChip from "@/components/atoms/todo-chip/TodoChip";
 
-const DROPDOWN_ITEMS = [
-  { label: "수정하기", onClick: () => alert("수정하기") },
-  { label: "삭제하기", onClick: () => alert("삭제하기") },
-];
-
 interface CardProps {
   children: ReactNode;
+}
+
+interface CardHeaderProps {
+  noteId: number;
 }
 
 export default function Card({ children }: CardProps) {
@@ -22,8 +22,25 @@ export default function Card({ children }: CardProps) {
   );
 }
 
-function CardHeader() {
+function CardHeader({ noteId }: CardHeaderProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+  const editPath = `/goal/${router.query.goalId}/notes?noteId=${noteId}&mode=edit`;
+
+  const handleClickEdit = () => {
+    router.push(editPath);
+  };
+  const handleClickDelete = () => {
+    alert("삭제하기");
+  };
+
+  const dropdownItems = [
+    {
+      label: "수정하기",
+      onClick: handleClickEdit,
+    },
+    { label: "삭제하기", onClick: handleClickDelete },
+  ];
 
   return (
     <div className="flex items-center justify-between">
@@ -43,7 +60,7 @@ function CardHeader() {
       />
       {
         <ActionDropdown
-          items={DROPDOWN_ITEMS}
+          items={dropdownItems}
           className="absolute top-[58px] right-6"
           isOpen={isOpen}
           setIsOpen={setIsOpen}

--- a/src/views/notes/card/Card.tsx
+++ b/src/views/notes/card/Card.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { ReactNode, useState } from "react";
 
+import { deleteNote } from "@/apis/note/deleteNote";
 import ActionDropdown from "@/components/atoms/action-dropdown/ActionDropdown";
 import Divider from "@/components/atoms/divider/Divider";
 import TodoChip from "@/components/atoms/todo-chip/TodoChip";
@@ -31,7 +32,8 @@ function CardHeader({ noteId }: CardHeaderProps) {
     router.push(editPath);
   };
   const handleClickDelete = () => {
-    alert("삭제하기");
+    // 임시 모달
+    if (confirm("")) deleteNote(noteId);
   };
 
   const dropdownItems = [

--- a/src/views/notes/empty-notes/EmptyNotes.tsx
+++ b/src/views/notes/empty-notes/EmptyNotes.tsx
@@ -1,0 +1,7 @@
+export default function EmptyNotes() {
+  return (
+    <h1 className="mt-[300px] self-center text-sm font-normal text-slate-500">
+      아직 등록된 노트가 없어요
+    </h1>
+  );
+}

--- a/src/views/notes/note-list/NoteList.tsx
+++ b/src/views/notes/note-list/NoteList.tsx
@@ -25,7 +25,7 @@ export default function NoteList({ notes, inViewRef }: noteListProps) {
               </Card.Body>
             </Card>
 
-            {/* 마지막 페이지의 마지막 노트보다 4개 위에있는 노트에 스크롤 감지 블록을 위치시킴 */}
+            {/* 마지막 노트보다 4개 위에있는 노트에 스크롤 감지 블록을 위치시킴 */}
             {notes.length - 5 === noteIdx && <div ref={inViewRef} />}
           </>
         );

--- a/src/views/notes/note-list/NoteList.tsx
+++ b/src/views/notes/note-list/NoteList.tsx
@@ -17,7 +17,7 @@ export default function NoteList({ data, inViewRef }: noteListProps) {
           return (
             <>
               <Card key={id}>
-                <Card.Header />
+                <Card.Header noteId={id} />
                 <Card.Body>
                   <Card.Title>{title}</Card.Title>
                   <Card.Divider />

--- a/src/views/notes/note-list/NoteList.tsx
+++ b/src/views/notes/note-list/NoteList.tsx
@@ -1,40 +1,35 @@
-import { InfiniteData } from "@tanstack/react-query";
-
 import { TeamIdNotesGet200Response } from "@/types/types";
 
 import Card from "../card/Card";
 
 interface noteListProps {
-  data: InfiniteData<TeamIdNotesGet200Response, unknown> | undefined;
+  notes: TeamIdNotesGet200Response["notes"] | undefined;
   inViewRef: (node?: Element | null) => void;
 }
 
-export default function NoteList({ data, inViewRef }: noteListProps) {
+export default function NoteList({ notes, inViewRef }: noteListProps) {
   return (
     <div className="flex flex-col gap-4">
-      {data?.pages.map((page, pageIdx) =>
-        page.notes.map(({ id, title, todo }, noteIdx, notes) => {
-          return (
-            <>
-              <Card key={id}>
-                <Card.Header noteId={id} />
-                <Card.Body>
-                  <Card.Title>{title}</Card.Title>
-                  <Card.Divider />
-                  <Card.Content>
-                    <Card.todoChip isDone={todo.done} />
-                    <Card.TodoTitle>{todo.title}</Card.TodoTitle>
-                  </Card.Content>
-                </Card.Body>
-              </Card>
+      {notes?.map(({ id, title, todo }, noteIdx, notes) => {
+        return (
+          <>
+            <Card key={id}>
+              <Card.Header noteId={id} />
+              <Card.Body>
+                <Card.Title>{title}</Card.Title>
+                <Card.Divider />
+                <Card.Content>
+                  <Card.todoChip isDone={todo.done} />
+                  <Card.TodoTitle>{todo.title}</Card.TodoTitle>
+                </Card.Content>
+              </Card.Body>
+            </Card>
 
-              {/* 마지막 페이지의 마지막 노트보다 4개 위에있는 노트에 스크롤 감지 블록을 위치시킴 */}
-              {pageIdx === data.pages.length - 1 &&
-                notes.length - 5 === noteIdx && <div ref={inViewRef} />}
-            </>
-          );
-        }),
-      )}
+            {/* 마지막 페이지의 마지막 노트보다 4개 위에있는 노트에 스크롤 감지 블록을 위치시킴 */}
+            {notes.length - 5 === noteIdx && <div ref={inViewRef} />}
+          </>
+        );
+      })}
     </div>
   );
 }

--- a/src/views/notes/note-list/NoteList.tsx
+++ b/src/views/notes/note-list/NoteList.tsx
@@ -2,6 +2,8 @@ import { TeamIdNotesGet200Response } from "@/types/types";
 
 import Card from "../card/Card";
 
+const SCROLL_TRIGGER_OFFSET = 4;
+
 interface noteListProps {
   notes: TeamIdNotesGet200Response["notes"] | undefined;
   inViewRef: (node?: Element | null) => void;
@@ -11,6 +13,10 @@ export default function NoteList({ notes, inViewRef }: noteListProps) {
   return (
     <div className="flex flex-col gap-4">
       {notes?.map(({ id, title, todo }, noteIdx, notes) => {
+        /* 미리 스크롤을 감지하기 위해 마지막 노트보다 SCROLL_TRIGGER_OFFSET 만큼 위에있는 노트에 스크롤 감지 블록을 위치시킴 */
+        const isShowScrollTrigger =
+          notes.length - (1 + SCROLL_TRIGGER_OFFSET) === noteIdx;
+
         return (
           <>
             <Card key={id}>
@@ -25,8 +31,7 @@ export default function NoteList({ notes, inViewRef }: noteListProps) {
               </Card.Body>
             </Card>
 
-            {/* 마지막 노트보다 4개 위에있는 노트에 스크롤 감지 블록을 위치시킴 */}
-            {notes.length - 5 === noteIdx && <div ref={inViewRef} />}
+            {isShowScrollTrigger && <div ref={inViewRef} />}
           </>
         );
       })}


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-160)
  
<br/>

## 📗 작업 내용

- 노트 수정 및 삭제 기능을 구현했습니다.
- 노트 수정 시, `?noteId=<noteId>&mode=edit` 경로로 이동하여 edit 사이드바가 렌더링되도록 처리했습니다.
- 노트 삭제 시, 낙관적 업데이트를 적용하여 즉각적인 반영이 이루어지도록 했습니다.
- 노트 리스트의 무한 스크롤 반환값을 select 옵션을 활용해 flat하게 가공했습니다.
- 노트가 없는 경우를 고려하여 UI 예외 처리를 추가했습니다.

<br/>

### 수정

https://github.com/user-attachments/assets/b8f8d349-6ed9-4e84-a4d4-2a4882775dae


<br/>

### 삭제

https://github.com/user-attachments/assets/8a1fda42-5391-4d60-a3f8-815992300a2c

<br/>

### 등록된 노트가 없는 경우


<img src="https://github.com/user-attachments/assets/d347f758-293a-4197-a15c-89123583fd44" width="500px"/>






<br/>


## 💬 리뷰 요구사항(선택)

- 로딩, 에러처리는 MVP 끝나면 추가하겠습니다 😢


