### PR TITLE
chore(TODO-169): [스토리북] 전역 autodocs 옵션 제거

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -22,7 +22,6 @@ const preview: Preview = {
       handlers: [...handlers],
     },
   },
-  tags: ["autodocs"],
   loaders: [mswLoader],
 
   decorators: [

--- a/src/components/atoms/action-dropdown/ActionDropdown.stories.tsx
+++ b/src/components/atoms/action-dropdown/ActionDropdown.stories.tsx
@@ -6,6 +6,7 @@ import ActionDropdown from "./ActionDropdown";
 const meta: Meta<typeof ActionDropdown> = {
   title: "Common/Atoms/ActionDropdown",
   component: ActionDropdown,
+  tags: ["autodocs"],
   argTypes: {
     isOpen: { control: "boolean" },
     size: {
@@ -22,6 +23,7 @@ export const Default: Story = {
   args: {
     isOpen: true,
     size: "sm",
+
     items: [
       { label: "Item 1", onClick: () => alert("Item 1") },
       { label: "Item 2", onClick: () => alert("Item 2") },

--- a/src/components/atoms/divider/Divider.stories.tsx
+++ b/src/components/atoms/divider/Divider.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Divider> = {
   title: "Common/Atoms/Divider",
+  tags: ["autodocs"],
+
   component: Divider,
   parameters: {
     docs: {

--- a/src/components/atoms/exit-btn/ExitBtn.stories.tsx
+++ b/src/components/atoms/exit-btn/ExitBtn.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof ExitBtn> = {
   title: "Common/Atoms/ExitBtn",
+  tags: ["autodocs"],
+
   component: ExitBtn,
 };
 

--- a/src/components/atoms/goal-item/GoalItem.stories.tsx
+++ b/src/components/atoms/goal-item/GoalItem.stories.tsx
@@ -4,6 +4,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 const meta: Meta<typeof GoalItem> = {
   title: "Common/Atoms/GoalItem",
   component: GoalItem,
+  tags: ["autodocs"],
+
   argTypes: {
     goal: { control: "text" },
     iconSize: {

--- a/src/components/atoms/page-title/PageTitle.stories.ts
+++ b/src/components/atoms/page-title/PageTitle.stories.ts
@@ -4,6 +4,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 const meta = {
   title: "Common/Atoms/PageTitle",
   component: PageTitle,
+  tags: ["autodocs"],
+
   argTypes: {
     title: {
       control: "text",

--- a/src/components/atoms/plus-icon/PlusIcon.stories.ts
+++ b/src/components/atoms/plus-icon/PlusIcon.stories.ts
@@ -4,6 +4,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 const meta = {
   title: "Common/Atoms/PlusIcon",
   component: PlusIcon,
+  tags: ["autodocs"],
+
   argTypes: {
     width: {
       control: "number",

--- a/src/components/atoms/spinner/Spinner.stories.tsx
+++ b/src/components/atoms/spinner/Spinner.stories.tsx
@@ -6,6 +6,7 @@ import Spinner from "./Spinner";
 const meta: Meta<typeof Spinner> = {
   title: "Common/Atoms/Spinner",
   component: Spinner,
+  tags: ["autodocs"],
 };
 
 export default meta;

--- a/src/components/atoms/todo-chip/TodoChip.stories.tsx
+++ b/src/components/atoms/todo-chip/TodoChip.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof TodoChip> = {
   title: "Common/Atoms/TodoChip",
+  tags: ["autodocs"],
+
   component: TodoChip,
 };
 
@@ -10,7 +12,7 @@ export default meta;
 
 type Story = StoryObj<typeof TodoChip>;
 
-export const todoChip: Story = {
+export const Default: Story = {
   args: {
     isDone: true,
   },


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-169)
  
<br/>

## 📗 작업 내용

- 스토리북 전역에 설정되어있던 ` tags: ["autodocs"]` 을 제거하였습니다.

- 사유: docs 때문에 버그가 발생하는 스토리가 존재하여, 해당 스토리는 docs를 넣지 않으려다보니 전역에 있는 autodocs 설정을 제거해야 했습니다.

- docs가 필요할 경우 개별 스토리에 넣어주세요.

<br/>



