### PR TITLE
feat(TODO-186): [할 일 페이지] 무한스크롤

### DIFF
--- a/src/components/organisms/todo-list/TodoList.tsx
+++ b/src/components/organisms/todo-list/TodoList.tsx
@@ -8,6 +8,8 @@ interface TodoListProps {
   handleToggleTodo: (todoId: number, isDone: boolean) => void;
   setSelectedTodoId: (todoId: number | null) => void;
   onOpenDeletePopup: (todoId: number) => void;
+  isShowGoal?: boolean;
+  isNew?: boolean;
 }
 
 export default function TodoList({
@@ -15,6 +17,8 @@ export default function TodoList({
   handleToggleTodo,
   setSelectedTodoId,
   onOpenDeletePopup,
+  isShowGoal,
+  isNew,
 }: TodoListProps) {
   const { openModal } = useModalContext();
 
@@ -34,6 +38,8 @@ export default function TodoList({
           }}
           onOpenDeletePopup={onOpenDeletePopup}
           setSelectedTodoId={setSelectedTodoId}
+          isShowGoal={isShowGoal}
+          isNew={isNew}
         />
       ))}
     </ul>

--- a/src/hooks/todo/useInfiniteTodo.ts
+++ b/src/hooks/todo/useInfiniteTodo.ts
@@ -1,10 +1,10 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 
 import instance from "@/apis/apiClient";
 import { TeamIdTodosGet200Response, teamIdTodosGetParams } from "@/types/types";
 
 export const useInfiniteTodo = () => {
-  return useInfiniteQuery<TeamIdTodosGet200Response>({
+  return useSuspenseInfiniteQuery<TeamIdTodosGet200Response>({
     queryKey: ["todos"],
     queryFn: async ({ pageParam }) => {
       const params: teamIdTodosGetParams = {

--- a/src/hooks/todo/useInfiniteTodo.ts
+++ b/src/hooks/todo/useInfiniteTodo.ts
@@ -12,7 +12,6 @@ export const useInfiniteTodo = () => {
         size: 40,
       };
       const response = await instance.get("todos", { params });
-      console.log("useInfiniteTodo - response.data:", response.data);
       return response.data;
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/src/hooks/todo/useInfiniteTodo.ts
+++ b/src/hooks/todo/useInfiniteTodo.ts
@@ -1,0 +1,21 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import instance from "@/apis/apiClient";
+import { TeamIdTodosGet200Response, teamIdTodosGetParams } from "@/types/types";
+
+export const useInfiniteTodo = () => {
+  return useInfiniteQuery<TeamIdTodosGet200Response>({
+    queryKey: ["todos"],
+    queryFn: async ({ pageParam }) => {
+      const params: teamIdTodosGetParams = {
+        cursor: pageParam as number,
+        size: 40,
+      };
+      const response = await instance.get("todos", { params });
+      console.log("useInfiniteTodo - response.data:", response.data);
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: null,
+  });
+};

--- a/src/hooks/todo/useInfiniteTodo.ts
+++ b/src/hooks/todo/useInfiniteTodo.ts
@@ -1,10 +1,18 @@
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 
 import instance from "@/apis/apiClient";
-import { TeamIdTodosGet200Response, teamIdTodosGetParams } from "@/types/types";
+import {
+  TeamIdTodosGet200Response,
+  teamIdTodosGetParams,
+  TodoResponseDto,
+} from "@/types/types";
 
 export const useInfiniteTodo = () => {
-  return useSuspenseInfiniteQuery<TeamIdTodosGet200Response>({
+  return useSuspenseInfiniteQuery<
+    TeamIdTodosGet200Response,
+    Error,
+    { todos: TodoResponseDto[]; totalCount: number }
+  >({
     queryKey: ["todos"],
     queryFn: async ({ pageParam }) => {
       const params: teamIdTodosGetParams = {
@@ -16,5 +24,9 @@ export const useInfiniteTodo = () => {
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: null,
+    select: (data) => ({
+      todos: data.pages.flatMap((page) => page.todos ?? []),
+      totalCount: data.pages[0]?.totalCount ?? 0,
+    }),
   });
 };

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -27,19 +27,13 @@ export default function TodoPage() {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [filter, setFilter] = useState<(typeof FILTER_TYPES)[number]>("All");
 
-  const allTodos = useMemo(() => {
-    return data?.pages.flatMap((page) => page.todos ?? []) ?? [];
-  }, [data?.pages]);
-
   const filteredTodos = useMemo(() => {
-    return allTodos.filter((todo) => {
+    return data.todos.filter((todo) => {
       if (filter === "Done") return todo.done;
       if (filter === "To do") return !todo.done;
       return true;
     });
-  }, [allTodos, filter]);
-
-  const totalCount = data?.pages[0]?.totalCount ?? 0;
+  }, [data.todos, filter]);
 
   const handleToggleTodo = useCallback(
     (todoId: number, isDone: boolean) => {
@@ -66,7 +60,7 @@ export default function TodoPage() {
     >
       <div className="flex items-center justify-between sm:max-w-[636px] md:max-w-[792px]">
         <h1 className="py-[18px] text-base font-semibold sm:text-lg">
-          모든 할일 ({totalCount})
+          모든 할일 ({data.totalCount})
         </h1>
 
         <button

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -27,7 +27,6 @@ export default function TodoPage() {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [filter, setFilter] = useState<(typeof FILTER_TYPES)[number]>("All");
 
-  console.log("(TodoPage) data 확인:", data);
   const allTodos = useMemo(() => {
     return data?.pages.flatMap((page) => page.todos ?? []) ?? [];
   }, [data?.pages]);

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -60,8 +60,8 @@ export default function TodoPage() {
   return (
     <div
       className={cn(
-        "flex flex-col bg-slate-100 px-4 text-slate-800",
-        "smd:pl-90 sm:h-screen sm:pl-21",
+        "flex min-h-[calc(100vh-48px)] flex-col bg-slate-100 px-4 text-slate-800",
+        "smd:pl-90 sm:min-h-screen sm:pl-21",
       )}
     >
       <div className="flex items-center justify-between sm:max-w-[636px] md:max-w-[792px]">

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -1,10 +1,11 @@
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useInView } from "react-intersection-observer";
 
 import PlusIcon from "@/components/atoms/plus-icon/PlusIcon";
 import Spinner from "@/components/atoms/spinner/Spinner";
 import { useModalContext } from "@/contexts/InputModalContext";
 import { useDeleteTodo } from "@/hooks/todo/useDeleteTodo";
-import { useTodos } from "@/hooks/todo/useTodos";
+import { useInfiniteTodo } from "@/hooks/todo/useInfiniteTodo";
 import { useUpdateTodo } from "@/hooks/todo/useUpdateTodo";
 import { cn } from "@/utils/cn";
 import DeletePopup from "@/views/todo/popup/DeletePopup";
@@ -15,26 +16,30 @@ import Todos from "@/views/todo/todoPage/Todos";
 export const FILTER_TYPES = ["All", "Done", "To do"] as const;
 
 export default function TodoPage() {
-  const { data } = useTodos();
+  const { ref: inViewRef, inView } = useInView();
+  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo();
   const toggleTodoMutation = useUpdateTodo();
   const deleteTodoMutation = useDeleteTodo();
   const { isOpen, openModal } = useModalContext();
 
   const [selectedTodoId, setSelectedTodoId] = useState<number | null>(null);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-
   const [filter, setFilter] = useState<(typeof FILTER_TYPES)[number]>("All");
 
   console.log("(TodoPage) data 확인:", data);
+  const allTodos = useMemo(() => {
+    return data?.pages.flatMap((page) => page.todos ?? []) ?? [];
+  }, [data?.pages]);
+
   const filteredTodos = useMemo(() => {
-    return (
-      (data?.todos ?? []).filter((todo) => {
-        if (filter === "Done") return todo.done;
-        if (filter === "To do") return !todo.done;
-        return true;
-      }) || []
-    );
-  }, [data?.todos, filter]);
+    return allTodos.filter((todo) => {
+      if (filter === "Done") return todo.done;
+      if (filter === "To do") return !todo.done;
+      return true;
+    });
+  }, [allTodos, filter]);
+
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
 
   const handleToggleTodo = useCallback(
     (todoId: number, isDone: boolean) => {
@@ -48,17 +53,20 @@ export default function TodoPage() {
     openModal();
   };
 
+  useEffect(() => {
+    if (inView && hasNextPage) fetchNextPage();
+  }, [inView, hasNextPage, fetchNextPage]);
+
   return (
     <div
       className={cn(
         "flex flex-col bg-slate-100 px-4 text-slate-800",
-        "h-[calc(100vh-48px)]",
         "smd:pl-90 sm:h-screen sm:pl-21",
       )}
     >
       <div className="flex items-center justify-between sm:max-w-[636px] md:max-w-[792px]">
         <h1 className="py-[18px] text-base font-semibold sm:text-lg">
-          모든 할일 ({data?.totalCount ?? 0})
+          모든 할일 ({totalCount})
         </h1>
 
         <button
@@ -72,6 +80,7 @@ export default function TodoPage() {
 
       <Suspense fallback={<Spinner size={60} />}>
         <Todos
+          inViewRef={inViewRef}
           todos={filteredTodos}
           filter={filter}
           setFilter={setFilter}

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -17,7 +17,8 @@ export const FILTER_TYPES = ["All", "Done", "To do"] as const;
 
 export default function TodoPage() {
   const { ref: inViewRef, inView } = useInView();
-  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteTodo();
   const toggleTodoMutation = useUpdateTodo();
   const deleteTodoMutation = useDeleteTodo();
   const { isOpen, openModal } = useModalContext();
@@ -87,6 +88,7 @@ export default function TodoPage() {
           handleToggleTodo={handleToggleTodo}
           setSelectedTodoId={setSelectedTodoId}
           setIsPopupOpen={() => setIsPopupOpen(true)}
+          isFetchingNextPage={isFetchingNextPage}
         />
       </Suspense>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "./fonts.css";
 @import "./toast.css";
 @import "./modal.css";
+@import "./slideUp.css";
 
 @theme {
   /* Font */

--- a/src/styles/slideUp.css
+++ b/src/styles/slideUp.css
@@ -1,0 +1,14 @@
+@theme {
+  --animate-slideUp: slideUp 0.3s ease-out forwards;
+
+  @keyframes slideUp {
+    0% {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}

--- a/src/views/dashboard/recent-todo/RecentTodo.tsx
+++ b/src/views/dashboard/recent-todo/RecentTodo.tsx
@@ -23,7 +23,6 @@ export default function RecentTodo({
     router.push("/todo");
   };
 
-  console.log("(RecentTodo) data 확인:", data);
   const todos = data?.todos ?? [];
 
   return (

--- a/src/views/todo/todo-item/TodoItem.tsx
+++ b/src/views/todo/todo-item/TodoItem.tsx
@@ -1,4 +1,5 @@
 import { TodoResponse } from "@/types/todo";
+import { cn } from "@/utils/cn";
 
 import { TodoCheckbox } from "../todo-checkbox/TodoCheckbox";
 import { ActionIcon } from "./action-icon/ActionIcon";
@@ -12,6 +13,7 @@ interface TodoItemProps {
   onOpenDeletePopup: (todoId: number) => void;
   setSelectedTodoId: (id: number | null) => void;
   isShowGoal?: boolean;
+  isNew?: boolean;
 }
 
 export function TodoItem({
@@ -22,9 +24,15 @@ export function TodoItem({
   onOpenDeletePopup,
   setSelectedTodoId,
   isShowGoal = false,
+  isNew = false,
 }: TodoItemProps) {
   return (
-    <li className="group mb-2 w-full last:mb-0">
+    <li
+      className={cn(
+        "group mb-2 w-full last:mb-0",
+        isNew && "animate-slideUp will-change-[transform,opacity]",
+      )}
+    >
       <div className="flex h-6 items-center">
         <TodoCheckbox
           checked={todo.done}

--- a/src/views/todo/todoPage/Todos.tsx
+++ b/src/views/todo/todoPage/Todos.tsx
@@ -12,6 +12,7 @@ const EMPTY_MESSAGE: Record<(typeof FILTER_TYPES)[number], string> = {
 };
 
 interface TodosProps {
+  inViewRef: (node?: Element | null) => void;
   todos: TodoResponseDto[];
   filter: (typeof FILTER_TYPES)[number];
   setFilter: Dispatch<SetStateAction<(typeof FILTER_TYPES)[number]>>;
@@ -21,6 +22,7 @@ interface TodosProps {
 }
 
 export default memo(function Todos({
+  inViewRef,
   todos,
   filter,
   setFilter,
@@ -46,12 +48,15 @@ export default memo(function Todos({
       </div>
 
       {todos.length > 0 ? (
-        <TodoList
-          data={todos}
-          handleToggleTodo={handleToggleTodo}
-          setSelectedTodoId={setSelectedTodoId}
-          onOpenDeletePopup={setIsPopupOpen}
-        />
+        <>
+          <TodoList
+            data={todos}
+            handleToggleTodo={handleToggleTodo}
+            setSelectedTodoId={setSelectedTodoId}
+            onOpenDeletePopup={setIsPopupOpen}
+          />
+          <div ref={inViewRef}></div>
+        </>
       ) : (
         <div className="flex flex-1 items-center justify-center text-sm font-normal text-slate-600">
           {EMPTY_MESSAGE[filter]}

--- a/src/views/todo/todoPage/Todos.tsx
+++ b/src/views/todo/todoPage/Todos.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, memo, SetStateAction } from "react";
 
+import Spinner from "@/components/atoms/spinner/Spinner";
 import TodoList from "@/components/organisms/todo-list/TodoList";
 import { FILTER_TYPES } from "@/pages/todo";
 import { TodoResponseDto } from "@/types/types";
@@ -19,6 +20,7 @@ interface TodosProps {
   handleToggleTodo: (todoId: number, isDone: boolean) => void;
   setSelectedTodoId: (todoId: number | null) => void;
   setIsPopupOpen: () => void;
+  isFetchingNextPage?: boolean;
 }
 
 export default memo(function Todos({
@@ -29,6 +31,7 @@ export default memo(function Todos({
   handleToggleTodo,
   setSelectedTodoId,
   setIsPopupOpen,
+  isFetchingNextPage,
 }: TodosProps) {
   return (
     <div className="mb-4 flex h-full flex-grow flex-col rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
@@ -56,6 +59,7 @@ export default memo(function Todos({
             setSelectedTodoId={setSelectedTodoId}
             onOpenDeletePopup={setIsPopupOpen}
           />
+          {isFetchingNextPage && <Spinner size={30} />}
           <div ref={inViewRef}></div>
         </>
       ) : (

--- a/src/views/todo/todoPage/Todos.tsx
+++ b/src/views/todo/todoPage/Todos.tsx
@@ -58,6 +58,8 @@ export default memo(function Todos({
             handleToggleTodo={handleToggleTodo}
             setSelectedTodoId={setSelectedTodoId}
             onOpenDeletePopup={setIsPopupOpen}
+            isShowGoal={true}
+            isNew={true}
           />
           {isFetchingNextPage && <Spinner size={30} />}
           <div ref={inViewRef}></div>

--- a/src/views/todo/todoPage/Todos.tsx
+++ b/src/views/todo/todoPage/Todos.tsx
@@ -43,6 +43,7 @@ export default memo(function Todos({
             )}
           >
             {type}
+            {filter !== "All" && filter === type && ` (${todos.length})`}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-186)
  
<br/>

## 📗 작업 내용

- 할 일 목록 페이지에 `useSuspenseInfiniteQuery`사용한 훅으로 교체해 무한스크롤 구현
- 할 일 나올 때 부드럽게 올라오는 애니메이션 적용(기능요구사항)

<br/>


## 💬 리뷰 요구사항(선택)

- 첫 페이지 이후의 **새 데이터(무한스크롤 시)에만 애니메이션 적용**은 좀 더 시간이 들 것 같아 추후 반영해보겠습니다.


