### PR TITLE
refactor(TODO-207): 할 일 목록페이지 BoundaryWrapper 적용

### DIFF
--- a/src/components/organisms/todo-list/todoList.stories.tsx
+++ b/src/components/organisms/todo-list/todoList.stories.tsx
@@ -1,0 +1,27 @@
+import { InputModalProvider } from "@/contexts/InputModalContext";
+import { sampleTodos } from "@/mocks/todo/todoMockData";
+
+import TodoList from "./TodoList";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TodoList> = {
+  title: "components/organisms/TodoList",
+  component: TodoList,
+  decorators: [
+    (Story) => (
+      <InputModalProvider>
+        <Story />
+      </InputModalProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TodoList>;
+
+export const Default: Story = {
+  args: {
+    data: sampleTodos,
+    handleToggleTodo: () => {},
+  },
+};

--- a/src/hooks/goal/useFetchGoals.ts
+++ b/src/hooks/goal/useFetchGoals.ts
@@ -15,7 +15,7 @@ export const useFetchGoals = () => {
     queryFn: async ({ pageParam }) => {
       const params: teamIdGoalsGetParams = {
         sortOrder: "newest",
-        size: 10,
+        size: 50,
         cursor: pageParam as number,
       };
 

--- a/src/mocks/todo/todoMockData.ts
+++ b/src/mocks/todo/todoMockData.ts
@@ -42,10 +42,10 @@ export const sampleTodos: TodoResponseDto[] = [
     teamId: "quesddo",
     createdAt: "2024-02-26T12:00:00Z",
     updatedAt: "2024-02-26T12:00:00Z",
-    noteId: 1,
+    noteId: null,
     linkUrl: "https://github.com/Quesddo/Client",
     fileUrl: "https://github.com/Quesddo/Client",
-    goal: null,
+    goal: { id: 1, title: "매일 꾸준히 운동하기" },
   },
   {
     id: 2,

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -2,6 +2,7 @@ import { Suspense, useCallback } from "react";
 
 import PlusIcon from "@/components/atoms/plus-icon/PlusIcon";
 import Spinner from "@/components/atoms/spinner/Spinner";
+import BoundaryWrapper from "@/components/organisms/boundary-wrapper/BoundaryWrapper";
 import { useModalContext } from "@/contexts/InputModalContext";
 import { useTodoListAction } from "@/hooks/useTodoListAction";
 import { cn } from "@/utils/cn";
@@ -47,13 +48,13 @@ export default function TodoPage() {
         </button>
       </div>
 
-      <Suspense fallback={<Spinner size={80} />}>
+      <BoundaryWrapper>
         <Todos
           handleToggleTodo={handleToggleTodo}
           setSelectedTodoId={setSelectedTodoId}
           onOpenDeletePopup={onOpenDeletePopup}
         />
-      </Suspense>
+      </BoundaryWrapper>
 
       {isOpen && !selectedTodoId && <TodoCreateForm />}
       {isOpen && selectedTodoId && <TodoUpdateForm todoId={selectedTodoId} />}

--- a/src/views/todo/TodoForm.tsx
+++ b/src/views/todo/TodoForm.tsx
@@ -94,7 +94,7 @@ export function TodoForm({
                 type="text"
                 placeholder="할 일의 제목을 적어주세요"
                 maxLength={30}
-                {...register("title", { required: true })}
+                {...register("title", { required: true, maxLength: 30 })}
               />
             </div>
 

--- a/src/views/todo/todo-item/TodoItem.tsx
+++ b/src/views/todo/todo-item/TodoItem.tsx
@@ -49,6 +49,7 @@ export function TodoItem({
       className={cn(
         "group mb-2 w-full last:mb-0",
         isNew && "animate-slideUp will-change-[transform,opacity]",
+        isMobile && "cursor-pointer",
       )}
     >
       <div className="flex h-6 items-center">

--- a/src/views/todo/todo-item/todoItem.stories.tsx
+++ b/src/views/todo/todo-item/todoItem.stories.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+import { sampleTodos } from "@/mocks/todo/todoMockData";
+
+import { TodoItem } from "./TodoItem";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TodoItem> = {
+  title: "views/todo/TodoItem",
+  component: TodoItem,
+  parameters: {
+    viewport: {
+      viewports: {
+        mobile: {
+          name: "Mobile",
+          styles: {
+            width: "375px",
+            height: "667px",
+          },
+        },
+      },
+      defaultViewport: "mobile",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TodoItem>;
+
+export const Default: Story = {
+  args: {
+    todo: sampleTodos[0],
+    handleToggleTodo: (todoId: number, isDone: boolean) =>
+      console.log(`${todoId}할일 체크 ${isDone}`),
+    onOpenTodoModal: () => console.log("모달 열기"),
+    onOpenDeletePopup: (todoId: number) => console.log(`${todoId}할일 삭제`),
+    isNew: true,
+    setIsTouchedId: (id: number | null) => console.log(`${id}클릭한 할일`),
+  },
+};
+
+// 모바일 환경 터치 상태
+export const MobileTouchedNShowGoal: Story = {
+  args: {
+    ...Default.args,
+    isTouched: true,
+    isShowGoal: true,
+  },
+  decorators: [
+    (Story) => {
+      const [isTouchedId, setIsTouchedId] = useState<number | null>(
+        sampleTodos[0].id,
+      );
+      return (
+        <Story
+          args={{
+            ...Default.args,
+            isTouched: isTouchedId === sampleTodos[0].id,
+            setIsTouchedId,
+            isShowGoal: true,
+          }}
+        />
+      );
+    },
+  ],
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-207)
  
<br/>

## 📗 작업 내용

- suspense만 적용되어있던 부분에 BoundaryWrapper 사용
- 할 일 목록 폼에서 일반 목록으로 불러오는 목표 최대 갯수 50으로 설정
- 할 일 목록 폼 title 글자 수 maxLength 제한 추가
- 할 일 목록 호버아이콘 터치 환경에서 마우스 커서포인터 추가

<br/>


## 💬 리뷰 요구사항(선택)

- hover해야 나오는 아이콘을 지금은 터치 환경에서 할일li 클릭하면 나오도록 해뒀는데.. 모든 환경에서 그렇게 되도록 해도 될 것 같다는 생각이 듭니다(클릭 시 hover 정지)

- spinner를 세로 중앙에 배치하고 싶으면 어떻게 해야할까요? 부모 레이아웃을 건드리기엔 제약이 있어서


