### PR TITLE
fix(TODO-204): 목표 상세 페이지 목표를 수정/삭제 시 사이드바와 맞지 않는 부분 수정

### DIFF
--- a/src/hooks/goal/useDeleteGoal.ts
+++ b/src/hooks/goal/useDeleteGoal.ts
@@ -1,10 +1,11 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 
 import instance from "@/apis/apiClient";
 
 export const useDeleteGoal = (goalId?: number) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async () => {
       const { data } = await instance.delete(`/goals/${goalId}`);
@@ -12,7 +13,7 @@ export const useDeleteGoal = (goalId?: number) => {
       return data;
     },
     onSuccess: () => {
-      alert("목표가 삭제 되었습니다.");
+      queryClient.invalidateQueries({ queryKey: ["goals"] });
       router.push("/dashboard");
     },
   });

--- a/src/hooks/goal/useUpdateGoal.ts
+++ b/src/hooks/goal/useUpdateGoal.ts
@@ -13,6 +13,7 @@ export const useUpdateGoal = (goalId: number) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["goal", goalId] });
+      queryClient.invalidateQueries({ queryKey: ["goals"] });
     },
   });
 };

--- a/src/pages/goal/[goalId]/index.tsx
+++ b/src/pages/goal/[goalId]/index.tsx
@@ -1,18 +1,12 @@
-import { cva } from "class-variance-authority";
 import Head from "next/head";
 import { useRouter } from "next/router";
 
 import PageTitle from "@/components/atoms/page-title/PageTitle";
 import { GoalDetailProvider } from "@/contexts/GoalDetailContext";
-import { cn } from "@/utils/cn";
 import GoalSection from "@/views/goal/component/GoalSection";
 import NoteSection from "@/views/goal/component/NoteSection";
 import Section from "@/views/goal/component/Section";
 import TodoListSection from "@/views/goal/component/TodoListSection";
-
-const layoutVariants = cva(
-  "h-full bg-slate-100 px-[16px] pt-[64px] sm:pl-[84px] sm:pr-[24px] sm:pt-[24px] md:px-[360px] flex flex-col gap-[16px]",
-);
 
 export default function GoalDetailPage() {
   const router = useRouter();
@@ -26,21 +20,19 @@ export default function GoalDetailPage() {
             <title>{goalId}</title>
           </Head>
         </div>
-        <div className={cn(layoutVariants())}>
+        <div
+          className={
+            "flex h-full flex-col gap-[16px] bg-slate-100 px-[16px] pt-[64px] sm:pt-[24px] sm:pr-[24px] sm:pl-[84px] md:px-[360px]"
+          }
+        >
           {/* 목표 */}
           <PageTitle title="목표" isMobileFixed={true} />
           {/* 목표 이름,진행률 */}
-          <Section className="relative bg-white hover:shadow">
-            <GoalSection />
-          </Section>
+          <GoalSection />
           {/* 노트 모아보기 */}
-          <Section className="bg-blue-100 hover:shadow">
-            <NoteSection />
-          </Section>
-          <Section className="flex flex-col gap-[16px] p-[0px] md:flex-row md:justify-between md:gap-[24px]">
-            {/* 투두 리스트 */}
-            <TodoListSection />
-          </Section>
+          <NoteSection />
+          {/* 투두 리스트 */}
+          <TodoListSection />
         </div>
       </GoalDetailProvider>
     </>

--- a/src/views/goal/component/GoalHeader.tsx
+++ b/src/views/goal/component/GoalHeader.tsx
@@ -1,0 +1,110 @@
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+import ActionDropdown from "@/components/atoms/action-dropdown/ActionDropdown";
+import GoalItem from "@/components/atoms/goal-item/GoalItem";
+import Input from "@/components/atoms/input/Input";
+import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
+import { useDeleteGoal } from "@/hooks/goal/useDeleteGoal";
+import { useFetchGoal } from "@/hooks/goal/useFetchGoal";
+import { useUpdateGoal } from "@/hooks/goal/useUpdateGoal";
+import meatBalls from "@public/icons/meatballs_menu.svg";
+
+import Modal from "./Modal";
+
+export default function GoalHeader() {
+  const { goalId } = useGoalDetailContext();
+
+  const [isOpenActionDropDown, setIsOpenActionDropDown] = useState(false);
+  const [isOpenModal, setIsOpenModal] = useState(false);
+  const [action, setAction] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { data } = useFetchGoal(goalId);
+  const { mutate: updateGoalName } = useUpdateGoal(goalId);
+  const { mutate: deleteGoal } = useDeleteGoal(goalId);
+
+  const handleClick = () => {
+    setIsOpenActionDropDown(true);
+  };
+
+  const onClickCloseModal = () => {
+    setIsOpenModal(false);
+  };
+
+  const onClickOpenModal = () => {
+    setIsOpenModal(true);
+  };
+
+  const onClickUpdateGoalName = () => {
+    updateGoalName(inputRef.current?.value as string);
+    setIsOpenModal(false);
+  };
+
+  const onClickDeleteGoal = () => {
+    deleteGoal();
+  };
+
+  return (
+    <>
+      <div className="flex h-[64px] justify-between pb-[24px]">
+        <GoalItem
+          goal={data?.title}
+          fontWeight="semibold"
+          iconSize="lg"
+          textSize="sm"
+        />
+        <Image
+          src={meatBalls}
+          alt="meat-balls"
+          width={24}
+          height={24}
+          onClick={handleClick}
+          className="cursor-pointer"
+        />
+        <ActionDropdown
+          isOpen={isOpenActionDropDown}
+          items={[
+            {
+              label: "수정하기",
+              onClick: () => {
+                onClickOpenModal();
+                setIsOpenActionDropDown(() => false);
+                setAction("update");
+              },
+            },
+            {
+              label: "삭제하기",
+              onClick: () => {
+                onClickOpenModal();
+                setIsOpenActionDropDown(() => false);
+                setAction("delete");
+              },
+            },
+          ]}
+          setIsOpen={setIsOpenActionDropDown}
+          className="absolute top-[56px] right-6"
+        />
+      </div>
+      <Modal
+        isOpen={isOpenModal}
+        onClose={onClickCloseModal}
+        onClick={
+          action === "update" ? onClickUpdateGoalName : onClickDeleteGoal
+        }
+      >
+        {action === "update" ? (
+          <Input
+            type="text"
+            placeholder="수정 할 이름을 작성해주세요"
+            ref={inputRef}
+          />
+        ) : (
+          <>
+            <p>목표를 삭제하시겠어요?</p>
+            <p>삭제된 목표는 복구할 수 없습니다.</p>
+          </>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/src/views/goal/component/GoalSection.tsx
+++ b/src/views/goal/component/GoalSection.tsx
@@ -8,6 +8,7 @@ import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
 import { useDeleteGoal } from "@/hooks/goal/useDeleteGoal";
 import { useFetchGoal } from "@/hooks/goal/useFetchGoal";
 import { useUpdateGoal } from "@/hooks/goal/useUpdateGoal";
+import Section from "@/views/goal/component/Section";
 import meatBalls from "@public/icons/meatballs_menu.svg";
 
 import Modal from "./Modal";
@@ -52,7 +53,7 @@ export default function GoalSection() {
   if (isPending) return null;
 
   return (
-    <>
+    <Section className="relative bg-white hover:shadow">
       <div className="mb-[24px] flex justify-between">
         <GoalItem
           goal={data?.title}
@@ -113,6 +114,6 @@ export default function GoalSection() {
           </>
         )}
       </Modal>
-    </>
+    </Section>
   );
 }

--- a/src/views/goal/component/GoalSection.tsx
+++ b/src/views/goal/component/GoalSection.tsx
@@ -1,119 +1,13 @@
-import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
-
-import ActionDropdown from "@/components/atoms/action-dropdown/ActionDropdown";
-import GoalItem from "@/components/atoms/goal-item/GoalItem";
-import Input from "@/components/atoms/input/Input";
-import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
-import { useDeleteGoal } from "@/hooks/goal/useDeleteGoal";
-import { useFetchGoal } from "@/hooks/goal/useFetchGoal";
-import { useUpdateGoal } from "@/hooks/goal/useUpdateGoal";
 import Section from "@/views/goal/component/Section";
-import meatBalls from "@public/icons/meatballs_menu.svg";
 
-import Modal from "./Modal";
+import GoalHeader from "./GoalHeader";
 import ProgressContainer from "./ProgressContainer";
 
 export default function GoalSection() {
-  const { goalId } = useGoalDetailContext();
-
-  const [isOpenActionDropDown, setIsOpenActionDropDown] = useState(false);
-  const [isOpenModal, setIsOpenModal] = useState(false);
-  const [action, setAction] = useState<string>("");
-  const inputRef = useRef<HTMLInputElement>(null);
-  const { data, isPending } = useFetchGoal(goalId);
-  const { mutate: updateGoalName } = useUpdateGoal(goalId);
-  const { mutate: deleteGoal } = useDeleteGoal(goalId);
-
-  useEffect(() => {
-    if (isPending) return;
-  }, [isPending]);
-
-  const handleClick = () => {
-    setIsOpenActionDropDown(true);
-  };
-
-  const onClickCloseModal = () => {
-    setIsOpenModal(false);
-  };
-
-  const onClickOpenModal = () => {
-    setIsOpenModal(true);
-  };
-
-  const onClickUpdateGoalName = () => {
-    updateGoalName(inputRef.current?.value as string);
-    setIsOpenModal(false);
-  };
-
-  const onClickDeleteGoal = () => {
-    deleteGoal();
-  };
-
-  if (isPending) return null;
-
   return (
     <Section className="relative bg-white hover:shadow">
-      <div className="mb-[24px] flex justify-between">
-        <GoalItem
-          goal={data?.title}
-          fontWeight="semibold"
-          iconSize="lg"
-          textSize="sm"
-        />
-        <Image
-          src={meatBalls}
-          alt="meat-balls"
-          width={24}
-          height={24}
-          onClick={handleClick}
-          className="cursor-pointer"
-        />
-        <ActionDropdown
-          isOpen={isOpenActionDropDown}
-          items={[
-            {
-              label: "수정하기",
-              onClick: () => {
-                onClickOpenModal();
-                setIsOpenActionDropDown(() => false);
-                setAction("update");
-              },
-            },
-            {
-              label: "삭제하기",
-              onClick: () => {
-                onClickOpenModal();
-                setIsOpenActionDropDown(() => false);
-                setAction("delete");
-              },
-            },
-          ]}
-          setIsOpen={setIsOpenActionDropDown}
-          className="absolute top-[56px] right-6"
-        />
-      </div>
+      <GoalHeader />
       <ProgressContainer />
-      <Modal
-        isOpen={isOpenModal}
-        onClose={onClickCloseModal}
-        onClick={
-          action === "update" ? onClickUpdateGoalName : onClickDeleteGoal
-        }
-      >
-        {action === "update" ? (
-          <Input
-            type="text"
-            placeholder="수정 할 이름을 작성해주세요"
-            ref={inputRef}
-          />
-        ) : (
-          <>
-            <p>목표를 삭제하시겠어요?</p>
-            <p>삭제된 목표는 복구할 수 없습니다.</p>
-          </>
-        )}
-      </Modal>
     </Section>
   );
 }

--- a/src/views/goal/component/NoteSection.tsx
+++ b/src/views/goal/component/NoteSection.tsx
@@ -1,30 +1,34 @@
+import arrowRight from "@public/icons/ic_arrow_right.svg";
 import note from "@public/icons/note.svg";
 import Image from "next/image";
 import Link from "next/link";
 
 import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
-import arrowRight from "@public/icons/ic_arrow_right.svg";
+
+import Section from "./Section";
 
 export default function NoteSection() {
   const { goalId } = useGoalDetailContext();
 
   return (
-    <Link href={`/goal/${goalId}/notes`}>
-      <div className="flex justify-between">
-        <div className="flex gap-[8px]">
-          <Image
-            src={note}
-            width={24}
-            height={24}
-            alt="note"
-            className="inline-block"
-          />
-          <span className="text-lg font-bold text-slate-800">
-            노트 모아보기
-          </span>
+    <Section className="bg-blue-100 hover:shadow">
+      <Link href={`/goal/${goalId}/notes`}>
+        <div className="flex justify-between">
+          <div className="flex gap-[8px]">
+            <Image
+              src={note}
+              width={24}
+              height={24}
+              alt="note"
+              className="inline-block"
+            />
+            <span className="text-lg font-bold text-slate-800">
+              노트 모아보기
+            </span>
+          </div>
+          <Image src={arrowRight} alt="arrow-right" />
         </div>
-        <Image src={arrowRight} alt="arrow-right" />
-      </div>
-    </Link>
+      </Link>
+    </Section>
   );
 }

--- a/src/views/goal/component/Section.tsx
+++ b/src/views/goal/component/Section.tsx
@@ -1,16 +1,17 @@
-import { cva } from "class-variance-authority";
 import { ReactNode } from "react";
 
 import { cn } from "@/utils/cn";
-
-const sectionVariants = cva("px-[24px] py-[16px] rounded-xl border-0");
-
 interface Container {
   children: ReactNode;
   className?: string;
 }
+
 export default function Container({ children, className }: Container) {
   return (
-    <section className={cn(sectionVariants({ className }))}>{children}</section>
+    <section
+      className={cn(`rounded-xl border-0 px-[24px] py-[16px] ${className}`)}
+    >
+      {children}
+    </section>
   );
 }

--- a/src/views/goal/component/Section.tsx
+++ b/src/views/goal/component/Section.tsx
@@ -6,7 +6,7 @@ interface Container {
   className?: string;
 }
 
-export default function Container({ children, className }: Container) {
+export default function Section({ children, className }: Container) {
   return (
     <section
       className={cn(`rounded-xl border-0 px-[24px] py-[16px] ${className}`)}

--- a/src/views/goal/component/TodoListSection.tsx
+++ b/src/views/goal/component/TodoListSection.tsx
@@ -66,7 +66,7 @@ export default function TodoListSection() {
             할일 추가
           </button>
         </div>
-        <div className="h-[168px] overflow-x-hidden overflow-y-scroll">
+        <div className="h-[168px] overflow-x-hidden overflow-y-auto pr-4">
           {todos?.length ? (
             <TodoList
               data={todos}
@@ -86,7 +86,7 @@ export default function TodoListSection() {
         <div className="mb-[16px] flex justify-between">
           <p className="text-lg font-bold">done</p>
         </div>
-        <div className="h-[168px] overflow-x-hidden overflow-y-scroll">
+        <div className="h-[168px] overflow-x-hidden overflow-y-auto pr-4">
           {dones?.length ? (
             <TodoList
               data={dones}

--- a/src/views/goal/component/TodoListSection.tsx
+++ b/src/views/goal/component/TodoListSection.tsx
@@ -53,7 +53,7 @@ export default function TodoListSection() {
   }, [goalId]);
 
   return (
-    <>
+    <Section className="flex flex-col gap-[16px] p-[0px] md:flex-row md:justify-between md:gap-[24px]">
       {/* todo list */}
       <Section className="flex-1 bg-white hover:shadow">
         <div className="mb-[16px] flex justify-between">
@@ -101,6 +101,7 @@ export default function TodoListSection() {
           )}
         </div>
       </Section>
+
       {isOpen && !selectedTodoId && <TodoCreateForm />}
       {isOpen && selectedTodoId && <TodoUpdateForm todoId={selectedTodoId} />}
       {isPopupOpen && selectedTodoId && (
@@ -115,6 +116,6 @@ export default function TodoListSection() {
           onCancel={() => setIsPopupOpen(false)}
         />
       )}
-    </>
+    </Section>
   );
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-204)
  


## 📗 작업 내용

- 목표 수정/삭제 시 사이드바의 내용과 다른부분을 수정했습니다.
- 할일/끝낸일의 스크롤 꽉 막힌 부분을 조금 수정했습니다.
- 기타
  - 컴포넌트 분리/위치 이동
  - 네이밍 수정

## 💬 리뷰 요구사항(선택)




