### PR TITLE
feat(TODO-210): [노트 상세] 노트 내용에 editor 라이브러리 적용

### DIFF
--- a/src/components/organisms/note-detail/components/NoteDetailContent.tsx
+++ b/src/components/organisms/note-detail/components/NoteDetailContent.tsx
@@ -6,6 +6,7 @@ import Divider from "@/components/atoms/divider/Divider";
 import GoalItem from "@/components/atoms/goal-item/GoalItem";
 import TodoChip from "@/components/atoms/todo-chip/TodoChip";
 import { formatDate } from "@/utils/formatDate/formatDate";
+import ReactQuillEditor from "@/views/note/editor/ReactQuillEditor";
 
 import EmbeddedContent from "./EmbeddedContent";
 import LinkItem from "./LinkItem";
@@ -55,9 +56,13 @@ export default function NoteDetailContent({ noteId }: NoteDetailContentProps) {
             <Divider />
           </div>
           <LinkItem linkUrl={data?.linkUrl} setIsEmbedOpen={setIsEmbedOpen} />
-          <p className="mb-30 h-full overflow-y-auto text-base font-normal text-slate-700">
-            {data?.content}
-          </p>
+          <div className="mb-30 overflow-y-auto pr-2">
+            <ReactQuillEditor
+              modules={{ toolbar: false }}
+              readOnly
+              value={data?.content}
+            />
+          </div>
         </div>
       </div>
     </>

--- a/src/views/note/editor/ReactQuillEditor.tsx
+++ b/src/views/note/editor/ReactQuillEditor.tsx
@@ -1,0 +1,39 @@
+import dynamic from "next/dynamic";
+import { ForwardedRef } from "react";
+import ReactQuill from "react-quill-new";
+
+import { cn } from "@/utils/cn";
+
+interface ReactQuillNewProps extends ReactQuill.ReactQuillProps {
+  forwardedRef?: ForwardedRef<ReactQuill>;
+}
+
+const ReactQuillEditor = dynamic(
+  async () => {
+    const { default: RQ } = await import("react-quill-new");
+
+    const ReactQuillNew = ({ forwardedRef, ...props }: ReactQuillNewProps) => (
+      <RQ
+        ref={forwardedRef}
+        {...props}
+        className={cn(
+          // container
+          "relative flex min-h-0 flex-1 flex-col-reverse gap-4",
+          // toolbar, link item
+          "[&_.ql-toolbar]:rounded-[22px] [&_.ql-toolbar.ql-snow]:!flex [&_.ql-toolbar.ql-snow_.ql-formats]:last:ml-auto [&_.ql-toolbar.ql-snow_.ql-formats]:last:rounded-full [&_.ql-toolbar.ql-snow_.ql-formats]:last:bg-slate-200",
+          // content container
+          "[&>.ql-container]:min-h-0 [&>.ql-container]:!text-base [&>.ql-container]:!font-normal [&>.ql-container.ql-snow]:!border-none",
+          // content, content placeholder
+          "[&_.ql-editor]:!p-0 [&_.ql-editor.ql-blank::before]:!left-0",
+        )}
+      />
+    );
+
+    return ReactQuillNew;
+  },
+  {
+    ssr: false,
+  },
+);
+
+export default ReactQuillEditor;

--- a/src/views/note/note-form/Editor.tsx
+++ b/src/views/note/note-form/Editor.tsx
@@ -1,31 +1,12 @@
 import "react-quill-new/dist/quill.snow.css";
 
-import dynamic from "next/dynamic";
-import { ForwardedRef, useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import ReactQuill from "react-quill-new";
 
 import { useModalContext } from "@/contexts/InputModalContext";
-import { cn } from "@/utils/cn";
 
-interface ReactQuillNewProps extends ReactQuill.ReactQuillProps {
-  forwardedRef: ForwardedRef<ReactQuill> | undefined;
-}
-
-const ReactQuillEditor = dynamic(
-  async () => {
-    const { default: RQ } = await import("react-quill-new");
-
-    const ReactQuillNew = ({ forwardedRef, ...props }: ReactQuillNewProps) => (
-      <RQ ref={forwardedRef} {...props} formats={props.formats ?? undefined} />
-    );
-
-    return ReactQuillNew;
-  },
-  {
-    ssr: false,
-  },
-);
+import ReactQuillEditor from "../editor/ReactQuillEditor";
 
 const toolbarOptions = [
   ["bold", "italic", "underline"],
@@ -77,22 +58,12 @@ export default function Editor() {
             forwardedRef={setEditorRef}
             theme="snow"
             modules={modules}
-            onChange={(value) => {
+            onChange={(value: string) => {
               onChange(value);
               handleChangePlainText();
             }}
             value={value}
             placeholder="내용을 입력하세요"
-            className={cn(
-              // container
-              "relative flex min-h-0 flex-1 flex-col-reverse gap-4",
-              // toolbar, link item
-              "[&_.ql-toolbar]:rounded-[22px] [&_.ql-toolbar.ql-snow]:!flex [&_.ql-toolbar.ql-snow_.ql-formats]:last:ml-auto [&_.ql-toolbar.ql-snow_.ql-formats]:last:rounded-full [&_.ql-toolbar.ql-snow_.ql-formats]:last:bg-slate-200",
-              // content container
-              "[&>.ql-container]:min-h-0 [&>.ql-container]:!text-base [&>.ql-container]:!font-normal [&>.ql-container.ql-snow]:!border-none",
-              // content, content placeholder
-              "[&_.ql-editor]:!p-0 [&_.ql-editor.ql-blank::before]:!left-0",
-            )}
           ></ReactQuillEditor>
           <input type="hidden" {...methods.register("plainText")} />
         </>


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-210)
  
<br/>

## 📗 작업 내용

- 노트 상세에 editor 라이브러리(react-quill)를 사용
  - 노트 작성/수정과 컨텐츠 스타일이 동일하도록 수정하였습니다.
  - 태그가 나오는 문제 처리

<br/>


## 💬 리뷰 요구사항(선택)

- 적용된 이미지
<img width="496" alt="스크린샷 2025-03-06 오전 11 46 16" src="https://github.com/user-attachments/assets/8014ad07-4ef3-4799-9fa3-7472d33b032c" />


