### PR TITLE
feat(TODO-215): [useTodos] 완료 여부에 따라 할 일 필터링하여 받아오도록 확장

### DIFF
--- a/src/apis/todoApi.ts
+++ b/src/apis/todoApi.ts
@@ -1,11 +1,39 @@
+import { FilterType } from "@/types/todo";
 import { TodoResponseDto } from "@/types/types";
 
 import instance from "./apiClient";
 
 export const todoApi = {
+  /**
+   * 단일 할 일 조회
+   */
   fetchTodo: async (todoId: number): Promise<TodoResponseDto> => {
     const { data } = await instance.get(`/todos/${todoId}`);
+    return data;
+  },
 
+  /**
+   * 할 일 리스트 조회
+   * - 모든 할 일(todo, done)을 조회하려면 filter를 지정하지 마세요.
+   */
+  fetchTodos: async (goalId?: number, size?: number, filter?: FilterType) => {
+    let isDone;
+    switch (filter) {
+      case "todo":
+        isDone = false;
+        break;
+      case "done":
+        isDone = true;
+        break;
+    }
+
+    const params = {
+      goalId,
+      isDone,
+      size,
+    };
+
+    const { data } = await instance.get("/todos", { params });
     return data;
   },
 };

--- a/src/apis/todoApi.ts
+++ b/src/apis/todoApi.ts
@@ -17,19 +17,19 @@ export const todoApi = {
    * - 모든 할 일(todo, done)을 조회하려면 filter를 지정하지 마세요.
    */
   fetchTodos: async (goalId?: number, size?: number, filter?: FilterType) => {
-    let isDone;
+    let done;
     switch (filter) {
       case "todo":
-        isDone = false;
+        done = false;
         break;
       case "done":
-        isDone = true;
+        done = true;
         break;
     }
 
     const params = {
       goalId,
-      isDone,
+      done,
       size,
     };
 

--- a/src/hooks/todo/useTodos.ts
+++ b/src/hooks/todo/useTodos.ts
@@ -1,14 +1,15 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 
-import instance from "@/apis/apiClient";
-import { TodoResponse } from "@/types/todo";
+import { todoApi } from "@/apis/todoApi";
+import { FilterType, TodoResponse } from "@/types/todo";
 
-export const useTodos = (goalId?: number) => {
+export const useTodos = (
+  goalId?: number,
+  size?: number,
+  filter?: FilterType,
+) => {
   return useSuspenseQuery<TodoResponse>({
-    queryKey: ["todos"],
-    queryFn: async () => {
-      const { data } = await instance.get(`/todos?goalId=${goalId ?? ""}`);
-      return data;
-    },
+    queryKey: ["todos", goalId, filter],
+    queryFn: () => todoApi.fetchTodos(goalId, size, filter),
   });
 };

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -20,3 +20,5 @@ export interface TodoItem {
   updatedAt: string;
   createdAt: string;
 }
+
+export type FilterType = "todo" | "done";


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-215)
  
<br/>

## 📗 작업 내용

- 할 일 데이터를 "todo", "done" 에 따라 필터링하여 받아와야할 필요가 생겨, filter 인자를 넣어줄 수 있도록 확장하였습니다.

- filter를 넣어주지 않으면 완료 여부와 관계 없이 모든 할 일을 불러옵니다.

- useTodos에서 queryFn을 API 폴더로 분리하였습니다.

<br/>



