### PR TITLE
feat(TODO-208): [노트 작성/수정] 임시저장 workflow 개선

### DIFF
--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -6,7 +6,7 @@ import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
 import useToast from "../useToast";
 import useNoteStorage from "./useNoteStorage";
 
-interface UseNoteDraftProps<
+interface UseAutoSaveNoteDraftProps<
   TNoteBody extends CreateNoteBodyDto | UpdateNoteBodyDto,
 > {
   id: number;
@@ -16,9 +16,9 @@ interface UseNoteDraftProps<
 
 const TOAST_INTERVAL_TIME = 1000 * 60 * 5;
 
-export default function useNoteDraft<
+export default function useAutoSaveNoteDraft<
   TNoteBody extends CreateNoteBodyDto | UpdateNoteBodyDto,
->({ id, methods, isEditMode }: UseNoteDraftProps<TNoteBody>) {
+>({ id, methods, isEditMode }: UseAutoSaveNoteDraftProps<TNoteBody>) {
   const {
     formState: { isDirty },
   } = methods;

--- a/src/hooks/note/useNoteDraft.ts
+++ b/src/hooks/note/useNoteDraft.ts
@@ -70,6 +70,12 @@ export default function useNoteDraft<
     addInterval();
   };
 
+  const getDraftNoteData = () => {
+    const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
+
+    return noteStorage.get(id) as TNoteBody | null;
+  };
+
   const handleLoadNoteDraft = () => {
     const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
 
@@ -98,5 +104,10 @@ export default function useNoteDraft<
     return () => unsubscribe();
   }, [watch]);
 
-  return { handleClickSaveDraft, handleLoadNoteDraft, isNoteDraftSaved };
+  return {
+    handleClickSaveDraft,
+    getDraftNoteData,
+    isNoteDraftSaved,
+    handleLoadNoteDraft,
+  };
 }

--- a/src/hooks/note/useNoteDraft.ts
+++ b/src/hooks/note/useNoteDraft.ts
@@ -80,6 +80,9 @@ export default function useNoteDraft<
         methods.setValue(
           key as Path<TNoteBody>,
           data[key as keyof TNoteBody] as PathValue<TNoteBody, Path<TNoteBody>>,
+          {
+            shouldValidate: true,
+          },
         );
       });
     }

--- a/src/hooks/note/useNoteDraft.ts
+++ b/src/hooks/note/useNoteDraft.ts
@@ -27,6 +27,8 @@ export default function useNoteDraft<
   const { addToast } = useToast();
   const toastIntervalRef = useRef<NodeJS.Timeout>(null);
 
+  const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
+
   const saveDraft = () => {
     const values = methods.getValues();
     const noteStorage =
@@ -70,15 +72,7 @@ export default function useNoteDraft<
     addInterval();
   };
 
-  const getDraftNoteData = () => {
-    const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
-
-    return noteStorage.get(id) as TNoteBody | null;
-  };
-
   const handleLoadNoteDraft = () => {
-    const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
-
     const data = noteStorage.get(id) as TNoteBody | null;
 
     if (data) {
@@ -91,12 +85,6 @@ export default function useNoteDraft<
     }
   };
 
-  const isNoteDraftSaved = () => {
-    const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
-
-    return !!noteStorage.get(id);
-  };
-
   // form 내용 변화 감지
   useEffect(() => {
     const { unsubscribe } = watch(checkFormkValueChange);
@@ -106,8 +94,9 @@ export default function useNoteDraft<
 
   return {
     handleClickSaveDraft,
-    getDraftNoteData,
-    isNoteDraftSaved,
     handleLoadNoteDraft,
+    isNoteDraftSaved: () => !!noteStorage.get(id),
+    getDraftNoteData: () => noteStorage.get(id) as TNoteBody | null,
+    removeNoteDraft: noteStorage.remove,
   };
 }

--- a/src/hooks/note/useNoteStorage.ts
+++ b/src/hooks/note/useNoteStorage.ts
@@ -1,0 +1,31 @@
+import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
+import {
+  CREATE_NOTE_STORAGE,
+  NoteStorage,
+  UPDATE_NOTE_STORAGE,
+} from "@/views/note/note-form/utils/noteStorage";
+
+interface UseNoteDraftProps {
+  id: number;
+  isEditMode: boolean;
+}
+
+export default function useNoteStorage({ id, isEditMode }: UseNoteDraftProps) {
+  const noteStorage = isEditMode ? UPDATE_NOTE_STORAGE : CREATE_NOTE_STORAGE;
+
+  const saveDraftNote = (values: CreateNoteBodyDto | UpdateNoteBodyDto) => {
+    if ("todoId" in values) {
+      noteStorage.set(id, values);
+    } else {
+      (noteStorage as NoteStorage<UpdateNoteBodyDto>).set(id, values);
+    }
+  };
+
+  return {
+    saveDraftNote,
+    isNoteDraftSaved: () => !!noteStorage.get(id),
+    getDraftNoteData: () =>
+      noteStorage.get(id) as CreateNoteBodyDto | UpdateNoteBodyDto | null,
+    removeNoteDraft: noteStorage.remove,
+  };
+}

--- a/src/views/note/editor/ReactQuillEditor.tsx
+++ b/src/views/note/editor/ReactQuillEditor.tsx
@@ -21,6 +21,8 @@ const ReactQuillEditor = dynamic(
           "relative flex min-h-0 flex-1 flex-col-reverse gap-4",
           // toolbar, link item
           "[&_.ql-toolbar]:rounded-[22px] [&_.ql-toolbar.ql-snow]:!flex [&_.ql-toolbar.ql-snow_.ql-formats]:last:ml-auto [&_.ql-toolbar.ql-snow_.ql-formats]:last:rounded-full [&_.ql-toolbar.ql-snow_.ql-formats]:last:bg-slate-200",
+          // color palette
+          "[&_.ql-snow_.ql-picker.ql-expanded_.ql-picker-options]:!top-auto [&_.ql-snow_.ql-picker.ql-expanded_.ql-picker-options]:!bottom-[100%]",
           // content container
           "[&>.ql-container]:min-h-0 [&>.ql-container]:!text-base [&>.ql-container]:!font-normal [&>.ql-container.ql-snow]:!border-none",
           // content, content placeholder

--- a/src/views/note/note-drawer/NoteDrawer.tsx
+++ b/src/views/note/note-drawer/NoteDrawer.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import ExitBtn from "@/components/atoms/exit-btn/ExitBtn";
 import Spinner from "@/components/atoms/spinner/Spinner";
 import ErrorFallback from "@/components/molecules/error-fallback/ErrorFallback";
+import BoundaryWrapper from "@/components/organisms/boundary-wrapper/BoundaryWrapper";
 import { InputModalProvider } from "@/contexts/InputModalContext";
 
 import NoteCreationForm from "../note-form/NoteCreationForm";
@@ -52,12 +53,10 @@ export default function NoteDrawer() {
     <div className="fixed inset-0 z-20 bg-black/50">
       <section className="fixed inset-0 flex flex-col gap-4 bg-white p-6 sm:left-auto sm:w-[512px] sm:border-l sm:border-slate-200 md:w-[800px]">
         <ExitBtn onClick={handleClick} />
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          <Suspense fallback={<Spinner size={80} />}>
-            {mode === MODE.CREATE && <NoteCreationForm todoId={todoId} />}
-            {mode === MODE.EDIT && <NoteUpdateForm noteId={noteId} />}
-          </Suspense>
-        </ErrorBoundary>
+        <BoundaryWrapper>
+          {mode === MODE.CREATE && <NoteCreationForm todoId={todoId} />}
+          {mode === MODE.EDIT && <NoteUpdateForm noteId={noteId} />}
+        </BoundaryWrapper>
       </section>
     </div>
   );

--- a/src/views/note/note-drawer/NoteDrawer.tsx
+++ b/src/views/note/note-drawer/NoteDrawer.tsx
@@ -52,14 +52,12 @@ export default function NoteDrawer() {
     <div className="fixed inset-0 z-20 bg-black/50">
       <section className="fixed inset-0 flex flex-col gap-4 bg-white p-6 sm:left-auto sm:w-[512px] sm:border-l sm:border-slate-200 md:w-[800px]">
         <ExitBtn onClick={handleClick} />
-        <InputModalProvider>
-          <ErrorBoundary FallbackComponent={ErrorFallback}>
-            <Suspense fallback={<Spinner size={80} />}>
-              {mode === MODE.CREATE && <NoteCreationForm todoId={todoId} />}
-              {mode === MODE.EDIT && <NoteUpdateForm noteId={noteId} />}
-            </Suspense>
-          </ErrorBoundary>
-        </InputModalProvider>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <Suspense fallback={<Spinner size={80} />}>
+            {mode === MODE.CREATE && <NoteCreationForm todoId={todoId} />}
+            {mode === MODE.EDIT && <NoteUpdateForm noteId={noteId} />}
+          </Suspense>
+        </ErrorBoundary>
       </section>
     </div>
   );

--- a/src/views/note/note-form/DraftNoteReminderToast.tsx
+++ b/src/views/note/note-form/DraftNoteReminderToast.tsx
@@ -1,26 +1,46 @@
 import { useMemo, useState } from "react";
+import { useFormContext } from "react-hook-form";
 
 import Button from "@/components/atoms/button/Button";
 import ExitBtn from "@/components/atoms/exit-btn/ExitBtn";
 import Popup from "@/components/molecules/popup/Popup";
+import useNoteStorage from "@/hooks/note/useNoteStorage";
 import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
 
-type NoteAllBodyType = CreateNoteBodyDto | UpdateNoteBodyDto | null;
-
 interface DraftNoteReminderToastProps {
-  isOpen: boolean;
-  getDraftNoteData: () => NoteAllBodyType;
-  loadNoteDraft: () => void;
+  id: number;
+  isEditMode: boolean;
 }
 
+type NoteBodyKeyType = (keyof (CreateNoteBodyDto | UpdateNoteBodyDto))[];
+
 export default function DraftNoteReminderToast({
-  isOpen,
-  getDraftNoteData,
-  loadNoteDraft,
+  id,
+  isEditMode,
 }: DraftNoteReminderToastProps) {
-  const [isOpenToast, setIsOpenToast] = useState(isOpen);
+  const methods = useFormContext();
+
+  const { isNoteDraftSaved, getDraftNoteData } = useNoteStorage({
+    id,
+    isEditMode,
+  });
+
+  const [isOpenToast, setIsOpenToast] = useState(isNoteDraftSaved());
   const [isOpenPopup, setIsOpenPopup] = useState(false);
   const draftNoteData = useMemo(() => getDraftNoteData(), [isOpenPopup]);
+
+  const loadNoteDraft = () => {
+    const data = getDraftNoteData();
+
+    if (data) {
+      (Object.keys(data) as NoteBodyKeyType).forEach((key) => {
+        methods.setValue(key as string, data[key], {
+          shouldValidate: true,
+          shouldDirty: false,
+        });
+      });
+    }
+  };
 
   const handleCloseToast = () => {
     setIsOpenToast(false);
@@ -40,52 +60,54 @@ export default function DraftNoteReminderToast({
   };
 
   return (
-    <>
-      <div
-        className="flex items-center justify-between gap-3 rounded-[28px] bg-blue-50 px-3 py-2.5 text-blue-500 data-[open=false]:hidden"
-        data-open={isOpenToast}
-      >
-        <div className="flex items-center gap-4">
-          <button onClick={handleCloseToast}>
-            <img
-              src="/icons/delete_circle.png"
-              alt="삭제"
-              width={24}
-              height={24}
-            />
-          </button>
-          <p>임시 저장된 노트가 있어요. 저장된 노트를 불러오시겠어요?</p>
-        </div>
-        <Button
-          variant="outline"
-          size="xs"
-          rounded
-          className="shrink-0"
-          onClick={handleOpenPopUp}
+    isOpenToast && (
+      <>
+        <div
+          className="flex items-center justify-between gap-3 rounded-[28px] bg-blue-50 px-3 py-2.5 text-blue-500 data-[open=false]:hidden"
+          data-open={isOpenToast}
         >
-          불러오기
-        </Button>
-      </div>
-      {isOpenPopup && (
-        <div>
-          <Popup
-            onClose={handleClosePopup}
-            onConfirm={handleConfirmPopup}
-            isCancelEnabled
-          >
-            <div className="flex flex-col pt-2">
-              <ExitBtn
-                className="absolute top-6 right-6"
-                onClick={handleClosePopup}
+          <div className="flex items-center gap-4">
+            <button onClick={handleCloseToast}>
+              <img
+                src="/icons/delete_circle.png"
+                alt="삭제"
+                width={24}
+                height={24}
               />
-              <p className="flex w-full flex-col items-center">
-                <span>‘{draftNoteData?.title || "제목 없음"}’</span>
-                <span>제목의 노트를 불러오시겠어요?</span>
-              </p>
-            </div>
-          </Popup>
+            </button>
+            <p>임시 저장된 노트가 있어요. 저장된 노트를 불러오시겠어요?</p>
+          </div>
+          <Button
+            variant="outline"
+            size="xs"
+            rounded
+            className="shrink-0"
+            onClick={handleOpenPopUp}
+          >
+            불러오기
+          </Button>
         </div>
-      )}
-    </>
+        {isOpenPopup && (
+          <div>
+            <Popup
+              onClose={handleClosePopup}
+              onConfirm={handleConfirmPopup}
+              isCancelEnabled
+            >
+              <div className="flex flex-col pt-2">
+                <ExitBtn
+                  className="absolute top-6 right-6"
+                  onClick={handleClosePopup}
+                />
+                <p className="flex w-full flex-col items-center">
+                  <span>‘{draftNoteData?.title || "제목 없음"}’</span>
+                  <span>제목의 노트를 불러오시겠어요?</span>
+                </p>
+              </div>
+            </Popup>
+          </div>
+        )}
+      </>
+    )
   );
 }

--- a/src/views/note/note-form/DraftNoteReminderToast.tsx
+++ b/src/views/note/note-form/DraftNoteReminderToast.tsx
@@ -1,47 +1,91 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import Button from "@/components/atoms/button/Button";
+import ExitBtn from "@/components/atoms/exit-btn/ExitBtn";
+import Popup from "@/components/molecules/popup/Popup";
+import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
+
+type NoteAllBodyType = CreateNoteBodyDto | UpdateNoteBodyDto | null;
 
 interface DraftNoteReminderToastProps {
   isOpen: boolean;
-  onLoadData: () => void;
+  getDraftNoteData: () => NoteAllBodyType;
+  loadNoteDraft: () => void;
 }
 
 export default function DraftNoteReminderToast({
   isOpen,
-  onLoadData,
+  getDraftNoteData,
+  loadNoteDraft,
 }: DraftNoteReminderToastProps) {
   const [isOpenToast, setIsOpenToast] = useState(isOpen);
+  const [isOpenPopup, setIsOpenPopup] = useState(false);
+  const draftNoteData = useMemo(() => getDraftNoteData(), [isOpenPopup]);
 
-  const handleClose = () => {
+  const handleCloseToast = () => {
     setIsOpenToast(false);
   };
 
+  const handleOpenPopUp = () => {
+    setIsOpenPopup(true);
+  };
+
+  const handleClosePopup = () => {
+    setIsOpenPopup(false);
+  };
+
+  const handleConfirmPopup = () => {
+    loadNoteDraft();
+    handleClosePopup();
+  };
+
   return (
-    <div
-      className="flex items-center justify-between gap-3 rounded-[28px] bg-blue-50 px-3 py-2.5 text-blue-500 data-[open=false]:hidden"
-      data-open={isOpenToast}
-    >
-      <div className="flex items-center gap-4">
-        <button onClick={handleClose}>
-          <img
-            src="/icons/delete_circle.png"
-            alt="삭제"
-            width={24}
-            height={24}
-          />
-        </button>
-        <p>임시 저장된 노트가 있어요. 저장된 노트를 불러오시겠어요?</p>
-      </div>
-      <Button
-        variant="outline"
-        size="xs"
-        rounded
-        className="shrink-0"
-        onClick={onLoadData}
+    <>
+      <div
+        className="flex items-center justify-between gap-3 rounded-[28px] bg-blue-50 px-3 py-2.5 text-blue-500 data-[open=false]:hidden"
+        data-open={isOpenToast}
       >
-        불러오기
-      </Button>
-    </div>
+        <div className="flex items-center gap-4">
+          <button onClick={handleCloseToast}>
+            <img
+              src="/icons/delete_circle.png"
+              alt="삭제"
+              width={24}
+              height={24}
+            />
+          </button>
+          <p>임시 저장된 노트가 있어요. 저장된 노트를 불러오시겠어요?</p>
+        </div>
+        <Button
+          variant="outline"
+          size="xs"
+          rounded
+          className="shrink-0"
+          onClick={handleOpenPopUp}
+        >
+          불러오기
+        </Button>
+      </div>
+      {isOpenPopup && (
+        <div>
+          <Popup
+            onClose={handleClosePopup}
+            onConfirm={handleConfirmPopup}
+            isCancelEnabled
+          >
+            <div className="flex flex-col pt-2">
+              <ExitBtn
+                className="absolute top-6 right-6"
+                onClick={handleClosePopup}
+              />
+              <p className="flex w-full flex-col items-center">
+                <span>‘{draftNoteData?.title || "제목 없음"}’</span>
+                <span>제목의 노트를 불러오시겠어요?</span>
+              </p>
+            </div>
+          </Popup>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/views/note/note-form/DraftNoteReminderToast.tsx
+++ b/src/views/note/note-form/DraftNoteReminderToast.tsx
@@ -2,12 +2,15 @@ import { useState } from "react";
 
 import Button from "@/components/atoms/button/Button";
 
-interface ToastBtnProps {
+interface DraftNoteReminderToastProps {
   isOpen: boolean;
   onLoadData: () => void;
 }
 
-export default function ToastBtn({ isOpen, onLoadData }: ToastBtnProps) {
+export default function DraftNoteReminderToast({
+  isOpen,
+  onLoadData,
+}: DraftNoteReminderToastProps) {
   const [isOpenToast, setIsOpenToast] = useState(isOpen);
 
   const handleClose = () => {

--- a/src/views/note/note-form/Editor.tsx
+++ b/src/views/note/note-form/Editor.tsx
@@ -37,6 +37,9 @@ export default function Editor() {
     methods.setValue(
       "plainText",
       editorRef.current?.getEditor().getText().replace(/\n+$/, ""),
+      {
+        shouldDirty: false,
+      },
     );
   };
 
@@ -48,12 +51,12 @@ export default function Editor() {
   }, []);
 
   return (
-    <Controller
-      control={methods.control}
-      name="content"
-      rules={{ required: true }}
-      render={({ field: { onChange, value } }) => (
-        <>
+    <>
+      <Controller
+        control={methods.control}
+        name="content"
+        rules={{ required: true }}
+        render={({ field: { onChange, value } }) => (
           <ReactQuillEditor
             forwardedRef={setEditorRef}
             theme="snow"
@@ -65,9 +68,9 @@ export default function Editor() {
             value={value}
             placeholder="내용을 입력하세요"
           ></ReactQuillEditor>
-          <input type="hidden" {...methods.register("plainText")} />
-        </>
-      )}
-    />
+        )}
+      />
+      <input type="hidden" defaultValue="" onChange={handleChangePlainText} />
+    </>
   );
 }

--- a/src/views/note/note-form/Editor.tsx
+++ b/src/views/note/note-form/Editor.tsx
@@ -58,6 +58,7 @@ export default function Editor() {
       methods.setValue("content", value, {
         shouldDirty: true,
       });
+      handleChangePlainText();
     }
   };
 

--- a/src/views/note/note-form/Editor.tsx
+++ b/src/views/note/note-form/Editor.tsx
@@ -20,7 +20,6 @@ export default function Editor() {
   const { openModal } = useModalContext();
   const methods = useFormContext();
   const editorRef = useRef<ReactQuill>(null);
-  const isDirtyContentRef = useRef(false);
 
   const modules = useMemo(
     () => ({
@@ -51,30 +50,22 @@ export default function Editor() {
     handleChangePlainText();
   }, []);
 
-  const handleChange = (value: string) => {
-    if (!isDirtyContentRef.current) {
-      isDirtyContentRef.current = true;
-    } else {
-      methods.setValue("content", value, {
-        shouldDirty: true,
-      });
-      handleChangePlainText();
-    }
-  };
-
   return (
     <>
       <Controller
         control={methods.control}
         name="content"
         rules={{ required: true }}
-        render={({ field: { value } }) => (
+        render={({ field: { onChange, value } }) => (
           <ReactQuillEditor
             forwardedRef={setEditorRef}
             theme="snow"
             modules={modules}
-            onChange={handleChange}
-            defaultValue={value}
+            onChange={(value: string) => {
+              onChange(value);
+              handleChangePlainText();
+            }}
+            value={value}
             placeholder="내용을 입력하세요"
           ></ReactQuillEditor>
         )}

--- a/src/views/note/note-form/Editor.tsx
+++ b/src/views/note/note-form/Editor.tsx
@@ -20,6 +20,7 @@ export default function Editor() {
   const { openModal } = useModalContext();
   const methods = useFormContext();
   const editorRef = useRef<ReactQuill>(null);
+  const isDirtyContentRef = useRef(false);
 
   const modules = useMemo(
     () => ({
@@ -50,22 +51,29 @@ export default function Editor() {
     handleChangePlainText();
   }, []);
 
+  const handleChange = (value: string) => {
+    if (!isDirtyContentRef.current) {
+      isDirtyContentRef.current = true;
+    } else {
+      methods.setValue("content", value, {
+        shouldDirty: true,
+      });
+    }
+  };
+
   return (
     <>
       <Controller
         control={methods.control}
         name="content"
         rules={{ required: true }}
-        render={({ field: { onChange, value } }) => (
+        render={({ field: { value } }) => (
           <ReactQuillEditor
             forwardedRef={setEditorRef}
             theme="snow"
             modules={modules}
-            onChange={(value: string) => {
-              onChange(value);
-              handleChangePlainText();
-            }}
-            value={value}
+            onChange={handleChange}
+            defaultValue={value}
             placeholder="내용을 입력하세요"
           ></ReactQuillEditor>
         )}

--- a/src/views/note/note-form/LinkModal.tsx
+++ b/src/views/note/note-form/LinkModal.tsx
@@ -1,4 +1,4 @@
-import { register } from "module";
+import { ChangeEventHandler } from "react";
 import { useFormContext } from "react-hook-form";
 
 import InputModal from "@/components/organisms/modal/InputModal";
@@ -11,12 +11,22 @@ export default function LinkModal({}) {
   const { closeModal } = useModalContext();
   const methods = useFormContext();
 
-  const resetTempUrl = () => {
-    methods.resetField("tempLinkUrl");
+  const resetTempUrl = () => {};
+
+  const handleChangeTempLinkUrl: ChangeEventHandler = (e) => {
+    methods.setValue(
+      "tempLinkUrl",
+      (e.currentTarget as HTMLInputElement).value,
+      {
+        shouldDirty: false,
+      },
+    );
   };
 
   const handleSubmitLink = () => {
-    methods.setValue("linkUrl", methods.getValues("tempLinkUrl"));
+    methods.setValue("linkUrl", methods.getValues("tempLinkUrl"), {
+      shouldDirty: true,
+    });
     resetTempUrl();
     closeModal();
   };
@@ -33,7 +43,8 @@ export default function LinkModal({}) {
           <InputModal.Label>링크</InputModal.Label>
           <InputModal.TextInput
             placeholder="링크를 입력하세요."
-            {...methods.register("tempLinkUrl", {})}
+            defaultValue=""
+            onChange={handleChangeTempLinkUrl}
           />
         </div>
         <input

--- a/src/views/note/note-form/NoteCreationForm.tsx
+++ b/src/views/note/note-form/NoteCreationForm.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 
 import { todoApi } from "@/apis/todoApi";
 import useCreateNote from "@/hooks/note/useCreateNote";
+import useNoteDraft from "@/hooks/note/useNoteDraft";
 import { CreateNoteBodyDto } from "@/types/types";
 
 import NoteForm from "./NoteForm";
@@ -24,11 +25,18 @@ export default function NoteCreationForm({ todoId }: NoteCreationFormProps) {
     queryFn: () => todoApi.fetchTodo(todoId),
   });
 
+  const { removeNoteDraft } = useNoteDraft({
+    id: todoId,
+    methods,
+    isEditMode: false,
+  });
+
   const handleSubmit = async (data: CreateNoteBodyDto) => {
     mutation.mutate(data, {
       onSuccess: (data) => {
         const queryParams = new URLSearchParams();
 
+        removeNoteDraft(todoId);
         queryParams.set("noteId", data.id.toString());
         queryParams.set("mode", "detail");
         router.push(`${pathname}?${queryParams.toString()}`);

--- a/src/views/note/note-form/NoteCreationForm.tsx
+++ b/src/views/note/note-form/NoteCreationForm.tsx
@@ -15,7 +15,14 @@ interface NoteCreationFormProps {
 }
 
 export default function NoteCreationForm({ todoId }: NoteCreationFormProps) {
-  const methods = useForm<CreateNoteBodyDto>();
+  const methods = useForm<CreateNoteBodyDto>({
+    defaultValues: {
+      title: "",
+      todoId,
+      content: "",
+      linkUrl: "",
+    },
+  });
   const mutation = useCreateNote();
   const pathname = usePathname();
   const router = useRouter();

--- a/src/views/note/note-form/NoteCreationForm.tsx
+++ b/src/views/note/note-form/NoteCreationForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 
 import { todoApi } from "@/apis/todoApi";
 import useCreateNote from "@/hooks/note/useCreateNote";
-import useNoteDraft from "@/hooks/note/useNoteDraft";
+import useNoteStorage from "@/hooks/note/useNoteStorage";
 import { CreateNoteBodyDto } from "@/types/types";
 
 import NoteForm from "./NoteForm";
@@ -32,9 +32,8 @@ export default function NoteCreationForm({ todoId }: NoteCreationFormProps) {
     queryFn: () => todoApi.fetchTodo(todoId),
   });
 
-  const { removeNoteDraft } = useNoteDraft({
+  const { removeNoteDraft } = useNoteStorage({
     id: todoId,
-    methods,
     isEditMode: false,
   });
 

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -5,9 +5,9 @@ import Button from "@/components/atoms/button/Button";
 import PageTitle from "@/components/atoms/page-title/PageTitle";
 import useNoteDraft from "@/hooks/note/useNoteDraft";
 import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
+import DraftNoteReminderToast from "@/views/note/note-form/DraftNoteReminderToast";
 import Editor from "@/views/note/note-form/Editor";
 import InputWithCount from "@/views/note/note-form/TitleCounter";
-import ToastBtn from "@/views/note/note-form/ToastBtn";
 
 import EditorTextCounter from "./EditorTextCounter";
 import GoalTodoDisplay from "./GoalTodoDisplay";
@@ -75,7 +75,7 @@ export default function NoteForm<
         </div>
         <div className="flex flex-col gap-4 pt-[11px] pb-[24px] sm:pt-4 md:flex-col-reverse">
           <GoalTodoDisplay goal={goal} todo={todo} />
-          <ToastBtn
+          <DraftNoteReminderToast
             isOpen={isNoteDraftSaved()}
             onLoadData={handleLoadNoteDraft}
           />

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -7,7 +7,7 @@ import useAutoSaveNoteDraft from "@/hooks/note/useAutoSaveNoteDraft";
 import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
 import DraftNoteReminderToast from "@/views/note/note-form/DraftNoteReminderToast";
 import Editor from "@/views/note/note-form/Editor";
-import InputWithCount from "@/views/note/note-form/TitleCounter";
+import TitleWithCounter from "@/views/note/note-form/TitleWithCounter";
 
 import EditorTextCounter from "./EditorTextCounter";
 import GoalTodoDisplay from "./GoalTodoDisplay";
@@ -76,7 +76,7 @@ export default function NoteForm<
           <GoalTodoDisplay goal={goal} todo={todo} />
           <DraftNoteReminderToast id={id} isEditMode={editMode} />
         </div>
-        <InputWithCount />
+        <TitleWithCounter />
         <div className="flex min-h-0 flex-1 flex-col gap-2">
           <EditorTextCounter />
           <LinkDisplay />

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -35,12 +35,16 @@ export default function NoteForm<
   todo,
   children,
 }: NoteFormProps<TNoteBody>) {
-  const { handleClickSaveDraft, handleLoadNoteDraft, isNoteDraftSaved } =
-    useNoteDraft({
-      id,
-      methods,
-      isEditMode: editMode,
-    });
+  const {
+    handleClickSaveDraft,
+    getDraftNoteData,
+    isNoteDraftSaved,
+    handleLoadNoteDraft,
+  } = useNoteDraft({
+    id,
+    methods,
+    isEditMode: editMode,
+  });
 
   const {
     formState: { isValid },
@@ -77,7 +81,8 @@ export default function NoteForm<
           <GoalTodoDisplay goal={goal} todo={todo} />
           <DraftNoteReminderToast
             isOpen={isNoteDraftSaved()}
-            onLoadData={handleLoadNoteDraft}
+            getDraftNoteData={getDraftNoteData}
+            loadNoteDraft={handleLoadNoteDraft}
           />
         </div>
         <InputWithCount />

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -3,7 +3,7 @@ import { FormProvider, type UseFormReturn } from "react-hook-form";
 
 import Button from "@/components/atoms/button/Button";
 import PageTitle from "@/components/atoms/page-title/PageTitle";
-import useNoteDraft from "@/hooks/note/useNoteDraft";
+import useAutoSaveNoteDraft from "@/hooks/note/useAutoSaveNoteDraft";
 import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
 import DraftNoteReminderToast from "@/views/note/note-form/DraftNoteReminderToast";
 import Editor from "@/views/note/note-form/Editor";
@@ -35,7 +35,7 @@ export default function NoteForm<
   todo,
   children,
 }: NoteFormProps<TNoteBody>) {
-  const { handleClickSaveDraft } = useNoteDraft({
+  const { handleClickSaveDraft } = useAutoSaveNoteDraft({
     id,
     methods,
     isEditMode: editMode,

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -35,12 +35,7 @@ export default function NoteForm<
   todo,
   children,
 }: NoteFormProps<TNoteBody>) {
-  const {
-    handleClickSaveDraft,
-    getDraftNoteData,
-    isNoteDraftSaved,
-    handleLoadNoteDraft,
-  } = useNoteDraft({
+  const { handleClickSaveDraft } = useNoteDraft({
     id,
     methods,
     isEditMode: editMode,
@@ -79,11 +74,7 @@ export default function NoteForm<
         </div>
         <div className="flex flex-col gap-4 pt-[11px] pb-[24px] sm:pt-4 md:flex-col-reverse">
           <GoalTodoDisplay goal={goal} todo={todo} />
-          <DraftNoteReminderToast
-            isOpen={isNoteDraftSaved()}
-            getDraftNoteData={getDraftNoteData}
-            loadNoteDraft={handleLoadNoteDraft}
-          />
+          <DraftNoteReminderToast id={id} isEditMode={editMode} />
         </div>
         <InputWithCount />
         <div className="flex min-h-0 flex-1 flex-col gap-2">

--- a/src/views/note/note-form/NoteUpdateForm.tsx
+++ b/src/views/note/note-form/NoteUpdateForm.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import noteApi from "@/apis/noteApi";
+import useNoteDraft from "@/hooks/note/useNoteDraft";
 import useUpdateNote from "@/hooks/note/useUpdateNote";
 import { UpdateNoteBodyDto } from "@/types/types";
 
@@ -25,11 +26,18 @@ export default function NoteUpdateForm({ noteId }: NoteUpdateFormProps) {
     queryFn: () => noteApi.fetchNote(noteId),
   });
 
+  const { removeNoteDraft } = useNoteDraft({
+    id: noteId,
+    methods,
+    isEditMode: true,
+  });
+
   const handleSubmit = (data: UpdateNoteBodyDto) => {
     mutation.mutate(data, {
       onSuccess: (data) => {
         const queryParams = new URLSearchParams();
 
+        removeNoteDraft(noteId);
         queryParams.set("noteId", data.id.toString());
         queryParams.set("mode", "detail");
         router.push(`${pathname}?${queryParams.toString()}`);

--- a/src/views/note/note-form/NoteUpdateForm.tsx
+++ b/src/views/note/note-form/NoteUpdateForm.tsx
@@ -16,7 +16,6 @@ interface NoteUpdateFormProps {
 }
 
 export default function NoteUpdateForm({ noteId }: NoteUpdateFormProps) {
-  const methods = useForm<UpdateNoteBodyDto>();
   const mutation = useUpdateNote(noteId);
   const pathname = usePathname();
   const router = useRouter();
@@ -24,6 +23,14 @@ export default function NoteUpdateForm({ noteId }: NoteUpdateFormProps) {
   const { data } = useSuspenseQuery({
     queryKey: ["noteDetail", noteId],
     queryFn: () => noteApi.fetchNote(noteId),
+  });
+
+  const methods = useForm<UpdateNoteBodyDto>({
+    defaultValues: {
+      title: data.title,
+      content: data.content,
+      linkUrl: data.linkUrl,
+    },
   });
 
   const { removeNoteDraft } = useNoteDraft({
@@ -44,13 +51,6 @@ export default function NoteUpdateForm({ noteId }: NoteUpdateFormProps) {
       },
     });
   };
-
-  useEffect(() => {
-    if (!data) return;
-    methods.setValue("title", data.title, { shouldValidate: true });
-    methods.setValue("content", data.content, { shouldValidate: true });
-    methods.setValue("linkUrl", data.linkUrl);
-  }, [data, methods]);
 
   return (
     <NoteForm

--- a/src/views/note/note-form/NoteUpdateForm.tsx
+++ b/src/views/note/note-form/NoteUpdateForm.tsx
@@ -1,11 +1,10 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import noteApi from "@/apis/noteApi";
-import useNoteDraft from "@/hooks/note/useNoteDraft";
+import useNoteStorage from "@/hooks/note/useNoteStorage";
 import useUpdateNote from "@/hooks/note/useUpdateNote";
 import { UpdateNoteBodyDto } from "@/types/types";
 
@@ -33,9 +32,8 @@ export default function NoteUpdateForm({ noteId }: NoteUpdateFormProps) {
     },
   });
 
-  const { removeNoteDraft } = useNoteDraft({
+  const { removeNoteDraft } = useNoteStorage({
     id: noteId,
-    methods,
     isEditMode: true,
   });
 

--- a/src/views/note/note-form/TitleWithCounter.tsx
+++ b/src/views/note/note-form/TitleWithCounter.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/utils/cn";
 
 const MAX_TITLE_COUNT = 30;
 
-export default function TitleCounter() {
+export default function TitleWithCounter() {
   const { register, watch } = useFormContext();
   const title = watch("title");
 

--- a/src/views/note/note-form/utils/noteStorage.ts
+++ b/src/views/note/note-form/utils/noteStorage.ts
@@ -56,7 +56,7 @@ export const UPDATE_NOTE_STORAGE: NoteStorage<UpdateNoteBodyDto> = {
       const parsedData = JSON.parse(data) as NoteStorageDataType;
       delete parsedData[noteId];
 
-      localStorage.setItem(NOTE_DRAFT_CREATE_KEY, JSON.stringify(parsedData));
+      localStorage.setItem(NOTE_DRAFT_UPDATE_KEY, JSON.stringify(parsedData));
     }
   },
 };

--- a/src/views/note/note-form/utils/noteStorage.ts
+++ b/src/views/note/note-form/utils/noteStorage.ts
@@ -15,9 +15,12 @@ export interface NoteStorage<T extends CreateNoteBodyDto | UpdateNoteBodyDto> {
 
 export const CREATE_NOTE_STORAGE: NoteStorage<CreateNoteBodyDto> = {
   set: (todoId, data) => {
+    const storageData = localStorage.getItem(NOTE_DRAFT_CREATE_KEY);
+    const storedData = storageData ? JSON.parse(storageData) : {};
+
     localStorage.setItem(
       NOTE_DRAFT_CREATE_KEY,
-      JSON.stringify({ [todoId]: { ...data, todoId } }),
+      JSON.stringify({ ...storedData, [todoId]: { ...data, todoId } }),
     );
   },
   get: (todoId) => {
@@ -39,9 +42,12 @@ export const CREATE_NOTE_STORAGE: NoteStorage<CreateNoteBodyDto> = {
 
 export const UPDATE_NOTE_STORAGE: NoteStorage<UpdateNoteBodyDto> = {
   set: (noteId: number, data: UpdateNoteBodyDto) => {
+    const storageData = localStorage.getItem(NOTE_DRAFT_UPDATE_KEY);
+    const storedData = storageData ? JSON.parse(storageData) : {};
+
     localStorage.setItem(
       NOTE_DRAFT_UPDATE_KEY,
-      JSON.stringify({ [noteId]: { ...data, noteId } }),
+      JSON.stringify({ ...storedData, [noteId]: { ...data, noteId } }),
     );
   },
   get: (noteId: number) => {


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-208)
  
<br/>

## 📗 작업 내용

- 임시저장
  - 불러오기 시 임시저장 제목 관련 팝업 모달 추가
  - 노트 작성/수정 완료 시 임시저장 노트는 제거
  - localStorage + Interval 처리가 함께 있던 hooks 분리
  - 하나의 노트만 저장되던 오류 처리
  - 토스트가 두 번 불러지는 오류 처리

- NoteDrawer에 있던 InputProvider 제거 (최상단 컴포넌트에 있기 때문)
- 컬러 팔레트 위치 조정

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


