### PR TITLE
feat(TODO-213): 목표상세 무한스크롤 기능

### DIFF
--- a/src/contexts/GoalDetailContext.tsx
+++ b/src/contexts/GoalDetailContext.tsx
@@ -1,15 +1,8 @@
-import { createContext, ReactNode, useContext, useState } from "react";
-
-import { useTodos } from "@/hooks/todo/useTodos";
+import { createContext, ReactNode, useContext } from "react";
 
 interface GoalDetailContextProps {
   goalId: number;
-  progress: number;
-  updateProgress: (doneCount: number) => void;
-  totalCount: number;
 }
-
-const MAX_TOTAL_COUNT = 9999;
 const GoalDetailContext = createContext<GoalDetailContextProps | null>(null);
 
 export const GoalDetailProvider = ({
@@ -19,23 +12,8 @@ export const GoalDetailProvider = ({
   children: ReactNode;
   goalId: number;
 }) => {
-  const [progress, setProgress] = useState<number>(0);
-  const { data } = useTodos(goalId, MAX_TOTAL_COUNT);
-  const { totalCount } = data;
-
-  const updateProgress = (doneCount: number) => {
-    if (totalCount > 0) {
-      setProgress(Math.round((doneCount / totalCount) * 100));
-    } else {
-      setProgress(0);
-    }
-  };
-
   const values: GoalDetailContextProps = {
     goalId,
-    progress,
-    updateProgress,
-    totalCount,
   };
 
   return (

--- a/src/contexts/GoalDetailContext.tsx
+++ b/src/contexts/GoalDetailContext.tsx
@@ -1,11 +1,15 @@
 import { createContext, ReactNode, useContext, useState } from "react";
 
+import { useTodos } from "@/hooks/todo/useTodos";
+
 interface GoalDetailContextProps {
   goalId: number;
   progress: number;
-  updateProgress: (doneCount: number, totalcount: number) => void;
+  updateProgress: (doneCount: number) => void;
+  totalCount: number;
 }
 
+const MAX_TOTAL_COUNT = 9999;
 const GoalDetailContext = createContext<GoalDetailContextProps | null>(null);
 
 export const GoalDetailProvider = ({
@@ -16,8 +20,10 @@ export const GoalDetailProvider = ({
   goalId: number;
 }) => {
   const [progress, setProgress] = useState<number>(0);
+  const { data } = useTodos(goalId, MAX_TOTAL_COUNT);
+  const { totalCount } = data;
 
-  const updateProgress = (doneCount: number, totalCount: number) => {
+  const updateProgress = (doneCount: number) => {
     if (totalCount > 0) {
       setProgress(Math.round((doneCount / totalCount) * 100));
     } else {
@@ -26,9 +32,10 @@ export const GoalDetailProvider = ({
   };
 
   const values: GoalDetailContextProps = {
+    goalId,
     progress,
     updateProgress,
-    goalId,
+    totalCount,
   };
 
   return (

--- a/src/hooks/todo/useInfiniteTodo.ts
+++ b/src/hooks/todo/useInfiniteTodo.ts
@@ -7,17 +7,28 @@ import {
   TodoResponseDto,
 } from "@/types/types";
 
-export const useInfiniteTodo = () => {
+type FilterType = "todo" | "done";
+
+export const useInfiniteTodo = (goalId?: number, filter?: FilterType) => {
   return useSuspenseInfiniteQuery<
     TeamIdTodosGet200Response,
     Error,
     { todos: TodoResponseDto[]; totalCount: number }
   >({
-    queryKey: ["todos", "infinite"],
+    queryKey: ["todos", "infinite", goalId, filter],
     queryFn: async ({ pageParam = 0 }) => {
+      let done, size;
+      if (filter === "todo") {
+        done = false;
+      }
+      if (filter === "done") {
+        done = true;
+      }
       const params: teamIdTodosGetParams = {
         cursor: pageParam as number,
-        size: 40,
+        size: size ?? 40,
+        goalId,
+        done,
       };
       const response = await instance.get("todos", { params });
       return response.data;

--- a/src/hooks/todo/useInfiniteTodo.ts
+++ b/src/hooks/todo/useInfiniteTodo.ts
@@ -9,7 +9,11 @@ import {
 
 type FilterType = "todo" | "done";
 
-export const useInfiniteTodo = (goalId?: number, filter?: FilterType) => {
+export const useInfiniteTodo = (
+  goalId?: number,
+  filter?: FilterType,
+  size = 40,
+) => {
   return useSuspenseInfiniteQuery<
     TeamIdTodosGet200Response,
     Error,
@@ -17,16 +21,17 @@ export const useInfiniteTodo = (goalId?: number, filter?: FilterType) => {
   >({
     queryKey: ["todos", "infinite", goalId, filter],
     queryFn: async ({ pageParam = 0 }) => {
-      let done, size;
-      if (filter === "todo") {
-        done = false;
-      }
-      if (filter === "done") {
-        done = true;
+      let done;
+      if (filter) {
+        if (filter === "todo") {
+          done = false;
+        } else {
+          done = true;
+        }
       }
       const params: teamIdTodosGetParams = {
         cursor: pageParam as number,
-        size: size ?? 40,
+        size: size,
         goalId,
         done,
       };

--- a/src/pages/goal/[goalId]/index.tsx
+++ b/src/pages/goal/[goalId]/index.tsx
@@ -13,20 +13,20 @@ export default function GoalDetailPage() {
 
   return (
     <GoalDetailProvider goalId={goalId}>
-      <div>
-        <Head>
-          <title>{goalId}</title>
-        </Head>
-      </div>
-      <div className="flex h-full flex-col gap-[16px] bg-slate-100 px-[16px] pt-[64px] sm:pt-[24px] sm:pr-[24px] sm:pl-[84px] md:px-[360px]">
-        {/* 목표 */}
-        <PageTitle title="목표" isMobileFixed={true} />
-        {/* 목표 이름,진행률 */}
-        <GoalHeader />
-        {/* 노트 모아보기 */}
-        <GoalNote />
-        {/* 투두 리스트 */}
-        <GoalTodoContainer />
+      <Head>
+        <title>{goalId}</title>
+      </Head>
+      <div className="box-border h-full bg-slate-100 px-[16px] pt-[64px] sm:pt-[24px] sm:pr-[24px] sm:pl-[84px] md:pl-[360px]">
+        <div className="flex max-w-[1200px] flex-col gap-[16px]">
+          {/* 목표 */}
+          <PageTitle title="목표" isMobileFixed={true} />
+          {/* 목표 이름,진행률 */}
+          <GoalHeader />
+          {/* 노트 모아보기 */}
+          <GoalNote />
+          {/* 투두 리스트 */}
+          <GoalTodoContainer />
+        </div>
       </div>
     </GoalDetailProvider>
   );

--- a/src/views/goal/header/Progress.tsx
+++ b/src/views/goal/header/Progress.tsx
@@ -1,7 +1,8 @@
 import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
+import useProgressTodo from "@/hooks/todo/useProgressTodo";
 
 import ProgressBar from "../../../components/atoms/progress-bar/ProgressBar";
 
@@ -32,7 +33,13 @@ export default function Progress({
   label = "Progress",
   showLabel = true,
 }: ProgressBarProps) {
-  const { progress } = useGoalDetailContext();
+  const { goalId } = useGoalDetailContext();
+  const { data } = useProgressTodo(goalId);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    setProgress(data.progress ?? 0);
+  }, [data]);
 
   return (
     <>
@@ -41,6 +48,7 @@ export default function Progress({
           {label}
         </p>
       )}
+
       <div className="flex items-center justify-between whitespace-nowrap">
         <ProgressBar progress={progress} />
         <p className="inline-block text-xs font-semibold">

--- a/src/views/goal/todo/GoalDoneList.tsx
+++ b/src/views/goal/todo/GoalDoneList.tsx
@@ -1,27 +1,58 @@
+import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+
+import TodoList from "@/components/organisms/todo-list/TodoList";
+import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
+import { useInfiniteTodo } from "@/hooks/todo/useInfiniteTodo";
+
 import Section from "../component/Section";
 
-export default function GoalDoneList() {
+interface GoalDoneListProps {
+  handleToggleTodo: (todoId: number, isDone: boolean) => void;
+  setSelectedTodoId: (todoId: number | null) => void;
+  onOpenDeletePopup: () => void;
+}
+
+export default function GoalDoneList({
+  handleToggleTodo,
+  setSelectedTodoId,
+  onOpenDeletePopup,
+}: GoalDoneListProps) {
+  const { goalId, updateProgress } = useGoalDetailContext();
+  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo(goalId, "done");
+  const { todos, totalCount } = data;
+
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && hasNextPage) fetchNextPage();
+  }, [inView]);
+
+  useEffect(() => {
+    updateProgress(totalCount);
+  }, [totalCount]);
+
   return (
     <Section className="flex-1 bg-slate-200 hover:shadow">
       <div className="mb-[16px] flex justify-between">
         <p className="text-lg font-bold">done</p>
       </div>
       <div className="h-[168px] overflow-x-hidden overflow-y-auto pr-4 md:h-[512px]">
-        <div className="flex h-full items-center justify-center text-sm font-normal text-slate-500">
-          다 한 일이 아직 없어요
-        </div>
-        {/* {dones?.length ? (
-          <TodoList
-            data={dones}
-            handleToggleTodo={handleToggleTodo}
-            setSelectedTodoId={setSelectedTodoId}
-            onOpenDeletePopup={() => setIsPopupOpen(true)}
-          />
+        {todos?.length ? (
+          <>
+            <TodoList
+              data={todos}
+              handleToggleTodo={handleToggleTodo}
+              setSelectedTodoId={setSelectedTodoId}
+              onOpenDeletePopup={onOpenDeletePopup}
+            />
+            <div ref={ref}></div>
+          </>
         ) : (
           <div className="flex h-full items-center justify-center text-sm font-normal text-slate-500">
             다 한 일이 아직 없어요
           </div>
-        )} */}
+        )}
       </div>
     </Section>
   );

--- a/src/views/goal/todo/GoalDoneList.tsx
+++ b/src/views/goal/todo/GoalDoneList.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 
@@ -18,22 +19,22 @@ export default function GoalDoneList({
   setSelectedTodoId,
   onOpenDeletePopup,
 }: GoalDoneListProps) {
-  const { goalId, updateProgress } = useGoalDetailContext();
+  const { goalId } = useGoalDetailContext();
   const { data, fetchNextPage, hasNextPage } = useInfiniteTodo(
     goalId,
     "done",
     20,
   );
   const { todos, totalCount } = data;
-
   const { ref, inView } = useInView();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (inView && hasNextPage) fetchNextPage();
   }, [inView]);
 
   useEffect(() => {
-    updateProgress(totalCount);
+    queryClient.invalidateQueries({ queryKey: ["progress", goalId] });
   }, [totalCount]);
 
   return (
@@ -42,7 +43,7 @@ export default function GoalDoneList({
         <p className="text-lg font-bold">done</p>
       </div>
       <div className="h-[168px] overflow-x-hidden overflow-y-auto pr-4 md:h-[512px]">
-        {todos?.length ? (
+        {totalCount ? (
           <>
             <TodoList
               data={todos}

--- a/src/views/goal/todo/GoalDoneList.tsx
+++ b/src/views/goal/todo/GoalDoneList.tsx
@@ -19,7 +19,11 @@ export default function GoalDoneList({
   onOpenDeletePopup,
 }: GoalDoneListProps) {
   const { goalId, updateProgress } = useGoalDetailContext();
-  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo(goalId, "done");
+  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo(
+    goalId,
+    "done",
+    20,
+  );
   const { todos, totalCount } = data;
 
   const { ref, inView } = useInView();

--- a/src/views/goal/todo/GoalTodoContainer.tsx
+++ b/src/views/goal/todo/GoalTodoContainer.tsx
@@ -7,9 +7,9 @@ import DeletePopup from "@/views/todo/popup/DeletePopup";
 import TodoCreateForm from "@/views/todo/todo-create-form/TodoCreateForm";
 import TodoUpdateForm from "@/views/todo/todo-update-form/TodoUpdateForm";
 
-import Section from "../component/Section";
 import GoalDoneList from "./GoalDoneList";
 import GoalTodoList from "./GoalTodoList";
+import Section from "../component/Section";
 
 export default function GoalTodoContainer() {
   /* todolist */
@@ -42,8 +42,11 @@ export default function GoalTodoContainer() {
         onOpenDeletePopup={onOpenDeletePopup}
       />
       {/* done list */}
-      <GoalDoneList />
-
+      <GoalDoneList
+        handleToggleTodo={handleToggleTodo}
+        setSelectedTodoId={setSelectedTodoId}
+        onOpenDeletePopup={onOpenDeletePopup}
+      />
       {isOpen && !selectedTodoId && <TodoCreateForm />}
       {isOpen && selectedTodoId && <TodoUpdateForm todoId={selectedTodoId} />}
       {isPopupOpen && selectedTodoId && (

--- a/src/views/goal/todo/GoalTodoList.tsx
+++ b/src/views/goal/todo/GoalTodoList.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 
 import PlusIcon from "@/components/atoms/plus-icon/PlusIcon";
-import BoundaryWrapper from "@/components/organisms/boundary-wrapper/BoundaryWrapper";
 import TodoList from "@/components/organisms/todo-list/TodoList";
 import { useGoalDetailContext } from "@/contexts/GoalDetailContext";
 import { useInfiniteTodo } from "@/hooks/todo/useInfiniteTodo";
@@ -24,7 +23,11 @@ export default function GoalTodoList({
   onOpenDeletePopup,
 }: GoalTodoListProps) {
   const { goalId } = useGoalDetailContext();
-  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo(goalId, "todo");
+  const { data, fetchNextPage, hasNextPage } = useInfiniteTodo(
+    goalId,
+    "todo",
+    20,
+  );
   const { todos, totalCount } = data;
   const { ref, inView } = useInView();
   const queryClient = useQueryClient();
@@ -50,23 +53,21 @@ export default function GoalTodoList({
         </button>
       </div>
       <div className="h-[168px] overflow-x-hidden overflow-y-auto pr-4 md:h-[512px]">
-        <BoundaryWrapper>
-          {todos?.length ? (
-            <>
-              <TodoList
-                data={todos}
-                handleToggleTodo={handleToggleTodo}
-                setSelectedTodoId={setSelectedTodoId}
-                onOpenDeletePopup={onOpenDeletePopup}
-              />
-              <div ref={ref}></div>
-            </>
-          ) : (
-            <div className="flex h-full items-center justify-center text-sm font-normal text-slate-500">
-              해야할 일이 아직 없어요
-            </div>
-          )}
-        </BoundaryWrapper>
+        {todos?.length ? (
+          <>
+            <TodoList
+              data={todos}
+              handleToggleTodo={handleToggleTodo}
+              setSelectedTodoId={setSelectedTodoId}
+              onOpenDeletePopup={onOpenDeletePopup}
+            />
+            <div ref={ref}></div>
+          </>
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm font-normal text-slate-500">
+            해야할 일이 아직 없어요
+          </div>
+        )}
       </div>
     </Section>
   );

--- a/src/views/goal/todo/GoalTodoList.tsx
+++ b/src/views/goal/todo/GoalTodoList.tsx
@@ -37,7 +37,7 @@ export default function GoalTodoList({
   }, [inView]);
 
   useEffect(() => {
-    queryClient.invalidateQueries({ queryKey: ["todos"] });
+    queryClient.invalidateQueries({ queryKey: ["progress", goalId] });
   }, [totalCount]);
 
   return (
@@ -53,7 +53,7 @@ export default function GoalTodoList({
         </button>
       </div>
       <div className="h-[168px] overflow-x-hidden overflow-y-auto pr-4 md:h-[512px]">
-        {todos?.length ? (
+        {totalCount ? (
           <>
             <TodoList
               data={todos}


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-213)
  
<br/>

## 📗 작업 내용

- 목표상세 무한스크롤 기능 추가
- todo list, done list 분리
- 레이아웃 수정
- progress 계산방식에서 api로 변경
  - 할일 추가를 했을 때 할일의 totalCount 수가 변경되어 api방식이 나은것으로 판단


## 💬 리뷰 요구사항(선택)

- 무한스크롤의 기능 동작은 하는데 원하는 동작인지는 모르겠네요
- 데이터 전처리는 다음 PR에 진행할 예정입니다.


