### PR TITLE
refactor(TODO-224): [할 일 수정폼] useEffect에서 상태설정 - 개선 시도

### DIFF
--- a/src/views/todo/todo-update-form/TodoUpdateForm.tsx
+++ b/src/views/todo/todo-update-form/TodoUpdateForm.tsx
@@ -31,33 +31,15 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
       reset(todo);
       setIsDone(todo.done || false);
 
-      if (todo.fileUrl) {
-        setIsFileCheck(true);
-        setValue("fileUrl", todo.fileUrl);
-      } else {
-        setIsFileCheck(false);
-      }
+      if (todo.fileUrl) setValue("fileUrl", todo.fileUrl);
+      setIsFileCheck(!!todo.fileUrl);
 
-      if (todo.linkUrl) {
-        setIsLinkCheck(true);
-        setSelectedInput("link");
-      } else {
-        setIsLinkCheck(false);
-      }
+      if (todo.linkUrl) setSelectedInput("link");
+      setIsLinkCheck(!!todo.linkUrl);
 
-      if (todo.goal?.id) {
-        setValue("goalId", todo.goal.id);
-      }
+      if (todo.goal?.id) setValue("goalId", todo.goal.id);
     }
-  }, [
-    todo,
-    reset,
-    setValue,
-    setIsDone,
-    setIsFileCheck,
-    setIsLinkCheck,
-    setSelectedInput,
-  ]);
+  }, [todo]);
 
   const updateTodoSubmit = (data: UpdateTodoBodyDto) => {
     updateTodoMutation.mutate(

--- a/src/views/todo/todo-update-form/TodoUpdateForm.tsx
+++ b/src/views/todo/todo-update-form/TodoUpdateForm.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { todoApi } from "@/apis/todoApi";
 import { useModalContext } from "@/contexts/InputModalContext";
@@ -26,8 +26,10 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
   const { setIsDone, setIsFileCheck, setIsLinkCheck, setSelectedInput } =
     todoformProps;
 
+  const isInitialized = useRef(false);
+
   useEffect(() => {
-    if (todo) {
+    if (todo && !isInitialized.current) {
       reset(todo);
       setIsDone(todo.done || false);
 
@@ -38,6 +40,8 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
       setIsLinkCheck(!!todo.linkUrl);
 
       if (todo.goal?.id) setValue("goalId", todo.goal.id);
+
+      isInitialized.current = true;
     }
   }, [todo]);
 

--- a/src/views/todo/todo-update-form/TodoUpdateForm.tsx
+++ b/src/views/todo/todo-update-form/TodoUpdateForm.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
-import instance from "@/apis/apiClient";
+import { todoApi } from "@/apis/todoApi";
 import { useModalContext } from "@/contexts/InputModalContext";
 import { useTodoForm } from "@/hooks/todo/form/useTodoForm";
 import { useUpdateTodo } from "@/hooks/todo/useUpdateTodo";
@@ -17,10 +17,7 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
 
   const { data: todo } = useQuery({
     queryKey: ["todo", todoId],
-    queryFn: async () => {
-      const response = await instance.get(`/todos/${todoId}`);
-      return response.data;
-    },
+    queryFn: () => todoApi.fetchTodo(todoId),
     enabled: !!todoId,
   });
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-224)
  
<br/>

## 📗 작업 내용

- MVP 피드백에서 언급된 지저분한 코드 리팩토링
- 조건문 간략하게 수정
- 의존성 배열에서 생략해도 안전할 함수들 제거

<br/>


## 💬 리뷰 요구사항(선택)

- useEffect를 다른 방법으로 바꿔보려 했지만, useQuery에서 onSuccess 옵션이 아예 제거된 이슈도 있고 useMemo로 바꾸어도 문제가 있어서 최대로 정리를 해보았습니다. 더 좋은 방법이 있다면 좋겠네요!


