### PR TITLE
refactor(TODO-213): 목표 상세에서 할 일 생성 시 기존 목표 세팅

### DIFF
--- a/src/apis/fileApi.ts
+++ b/src/apis/fileApi.ts
@@ -1,26 +1,17 @@
 import instance from "./apiClient";
 
-export class FileApi {
-  /**
-   * 파일 업로드
-   * @param file 업로드할 파일
-   * @returns 업로드된 파일의 URL
-   */
-  async uploadFile(file: File): Promise<{ url: string }> {
-    const formData = new FormData();
-    formData.append("file", file);
+export const uploadFile = async (file: File): Promise<{ url: string }> => {
+  const formData = new FormData();
+  formData.append("file", file);
 
-    try {
-      const { data } = await instance.post("files", formData, {
-        headers: { "Content-Type": "multipart/form-data" },
-      });
-      return data;
-    } catch (error) {
-      throw new Error(
-        `파일 업로드 실패: ${error instanceof Error ? error.message : "알 수 없는 오류"}`,
-      );
-    }
+  try {
+    const response = await instance.post("files", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      `파일 업로드 실패: ${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+    );
   }
-}
-
-export const fileApi = new FileApi();
+};

--- a/src/apis/fileApi.ts
+++ b/src/apis/fileApi.ts
@@ -1,0 +1,26 @@
+import instance from "./apiClient";
+
+export class FileApi {
+  /**
+   * 파일 업로드
+   * @param file 업로드할 파일
+   * @returns 업로드된 파일의 URL
+   */
+  async uploadFile(file: File): Promise<{ url: string }> {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const { data } = await instance.post("files", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      return data;
+    } catch (error) {
+      throw new Error(
+        `파일 업로드 실패: ${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+      );
+    }
+  }
+}
+
+export const fileApi = new FileApi();

--- a/src/hooks/todo/form/useTodoForm.ts
+++ b/src/hooks/todo/form/useTodoForm.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
-import instance from "@/apis/apiClient";
 import { fileApi } from "@/apis/fileApi";
+import useToast from "@/hooks/useToast";
 import { TodoResponseDto, UpdateTodoBodyDto } from "@/types/types";
 
 export function useTodoForm(
@@ -10,6 +10,7 @@ export function useTodoForm(
   todo?: TodoResponseDto,
   goalId?: number,
 ) {
+  const { addToast } = useToast();
   const formMethods = useForm<UpdateTodoBodyDto>();
   const { reset, setValue } = formMethods;
 
@@ -25,7 +26,10 @@ export function useTodoForm(
         const response = await fileApi.uploadFile(file);
         setValue("fileUrl", response.url);
       } catch (error) {
-        console.error("파일 업로드 오류:", error);
+        addToast({
+          variant: "error",
+          content: "파일 업로드에 실패했습니다.",
+        });
       }
     }
   };

--- a/src/hooks/todo/form/useTodoForm.ts
+++ b/src/hooks/todo/form/useTodoForm.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { fileApi } from "@/apis/fileApi";
+import { uploadFile } from "@/apis/fileApi";
 import useToast from "@/hooks/useToast";
 import { TodoResponseDto, UpdateTodoBodyDto } from "@/types/types";
 
@@ -23,7 +23,7 @@ export function useTodoForm(
     if (files.length > 0) {
       const file = files[0];
       try {
-        const response = await fileApi.uploadFile(file);
+        const response = await uploadFile(file);
         setValue("fileUrl", response.url);
       } catch (error) {
         addToast({

--- a/src/hooks/todo/form/useTodoForm.ts
+++ b/src/hooks/todo/form/useTodoForm.ts
@@ -5,11 +5,13 @@ import { uploadFile } from "@/apis/fileApi";
 import useToast from "@/hooks/useToast";
 import { TodoResponseDto, UpdateTodoBodyDto } from "@/types/types";
 
-export function useTodoForm(
-  isUpdate: boolean = false,
-  todo?: TodoResponseDto,
-  goalId?: number,
-) {
+interface TodoFormOptions {
+  isUpdate?: boolean;
+  todo?: TodoResponseDto;
+  goalId?: number;
+}
+
+export function useTodoForm({ isUpdate, todo, goalId }: TodoFormOptions) {
   const { addToast } = useToast();
   const formMethods = useForm<UpdateTodoBodyDto>();
   const { reset, setValue } = formMethods;

--- a/src/hooks/todo/form/useTodoForm.ts
+++ b/src/hooks/todo/form/useTodoForm.ts
@@ -1,12 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import instance from "@/apis/apiClient";
-import { UpdateTodoBodyDto } from "@/types/types";
+import { TodoResponseDto, UpdateTodoBodyDto } from "@/types/types";
 
-export function useTodoForm(isUpdate: boolean = false) {
+export function useTodoForm(isUpdate: boolean = false, todo?: TodoResponseDto) {
   const formMethods = useForm<UpdateTodoBodyDto>();
-  const { setValue } = formMethods;
+  const { reset, setValue } = formMethods;
 
   const [isDone, setIsDone] = useState(false);
   const [isFileCheck, setIsFileCheck] = useState(true);
@@ -28,6 +28,19 @@ export function useTodoForm(isUpdate: boolean = false) {
       }
     }
   };
+
+  useEffect(() => {
+    if (todo) {
+      reset(todo);
+      setIsDone(todo.done || false);
+
+      if (todo.fileUrl) setValue("fileUrl", todo.fileUrl);
+      setIsFileCheck(!!todo.fileUrl);
+      if (todo.linkUrl) setSelectedInput("link");
+      setIsLinkCheck(!!todo.linkUrl);
+      if (todo.goal?.id) setValue("goalId", todo.goal.id);
+    }
+  }, [todo]);
 
   const onSubmit = (
     data: UpdateTodoBodyDto,

--- a/src/hooks/todo/form/useTodoForm.ts
+++ b/src/hooks/todo/form/useTodoForm.ts
@@ -4,7 +4,11 @@ import { useForm } from "react-hook-form";
 import instance from "@/apis/apiClient";
 import { TodoResponseDto, UpdateTodoBodyDto } from "@/types/types";
 
-export function useTodoForm(isUpdate: boolean = false, todo?: TodoResponseDto) {
+export function useTodoForm(
+  isUpdate: boolean = false,
+  todo?: TodoResponseDto,
+  goalId?: number,
+) {
   const formMethods = useForm<UpdateTodoBodyDto>();
   const { reset, setValue } = formMethods;
 
@@ -39,8 +43,10 @@ export function useTodoForm(isUpdate: boolean = false, todo?: TodoResponseDto) {
       if (todo.linkUrl) setSelectedInput("link");
       setIsLinkCheck(!!todo.linkUrl);
       if (todo.goal?.id) setValue("goalId", todo.goal.id);
+    } else if (!isUpdate && goalId) {
+      setValue("goalId", goalId);
     }
-  }, [todo]);
+  }, [todo, goalId, isUpdate]);
 
   const onSubmit = (
     data: UpdateTodoBodyDto,

--- a/src/hooks/todo/form/useTodoForm.ts
+++ b/src/hooks/todo/form/useTodoForm.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import instance from "@/apis/apiClient";
+import { fileApi } from "@/apis/fileApi";
 import { TodoResponseDto, UpdateTodoBodyDto } from "@/types/types";
 
 export function useTodoForm(
@@ -20,13 +21,9 @@ export function useTodoForm(
   const handleFileChange = async (files: FileList) => {
     if (files.length > 0) {
       const file = files[0];
-      const formData = new FormData();
-      formData.append("file", file);
       try {
-        const response = await instance.post("files", formData, {
-          headers: { "Content-Type": "multipart/form-data" },
-        });
-        setValue("fileUrl", response.data.url);
+        const response = await fileApi.uploadFile(file);
+        setValue("fileUrl", response.url);
       } catch (error) {
         console.error("파일 업로드 오류:", error);
       }

--- a/src/views/goal/todo/GoalTodoContainer.tsx
+++ b/src/views/goal/todo/GoalTodoContainer.tsx
@@ -18,13 +18,17 @@ export default function GoalTodoContainer() {
   const deleteTodoMutation = useDeleteTodo();
   const [selectedTodoId, setSelectedTodoId] = useState<number | null>(null);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [createGoalId, setCreateGoalId] = useState<number | undefined>(
+    undefined,
+  );
 
   const handleToggleTodo = (todoId: number, isDone: boolean) => {
     toggleTodoMutation.mutate({ todoId, data: { done: !isDone } });
   };
 
-  const handleClickOpenCreateModal = () => {
+  const handleClickOpenCreateModal = (goalId: number) => {
     setSelectedTodoId(null);
+    setCreateGoalId(goalId);
     openModal("createTodo");
   };
 
@@ -48,7 +52,7 @@ export default function GoalTodoContainer() {
         onOpenDeletePopup={onOpenDeletePopup}
       />
 
-      {modalType === "createTodo" && <TodoCreateForm />}
+      {modalType === "createTodo" && <TodoCreateForm goalId={createGoalId} />}
       {modalType === "updateTodo" && selectedTodoId && (
         <TodoUpdateForm todoId={selectedTodoId} />
       )}

--- a/src/views/goal/todo/GoalTodoList.tsx
+++ b/src/views/goal/todo/GoalTodoList.tsx
@@ -9,7 +9,7 @@ import { useInfiniteTodo } from "@/hooks/todo/useInfiniteTodo";
 import Section from "../component/Section";
 
 interface GoalTodoListProps {
-  handleClick: () => void;
+  handleClick: (goalId: number) => void;
   handleToggleTodo: (todoId: number, isDone: boolean) => void;
   setSelectedTodoId: (todoId: number | null) => void;
   onOpenDeletePopup: () => void;
@@ -39,7 +39,7 @@ export default function GoalTodoList({
       <div className="mb-[16px] flex justify-between">
         <p className="text-lg font-bold">To do</p>
         <button
-          onClick={handleClick}
+          onClick={() => handleClick(goalId)}
           className="flex items-center gap-1 text-sm font-semibold text-blue-500"
         >
           <PlusIcon width={16} height={16} />

--- a/src/views/todo/todo-create-form/TodoCreateForm.tsx
+++ b/src/views/todo/todo-create-form/TodoCreateForm.tsx
@@ -6,10 +6,10 @@ import { UpdateTodoBodyDto } from "@/types/types";
 
 import { TodoForm } from "../TodoForm";
 
-export default function TodoCreateForm() {
+export default function TodoCreateForm({ goalId }: { goalId?: number }) {
   const { addToast } = useToast();
   const { closeModal } = useModalContext();
-  const todoformProps = useTodoForm();
+  const todoformProps = useTodoForm(false, undefined, goalId);
   const { reset } = todoformProps.formMethods;
 
   const createTodoMutation = useCreateTodo();

--- a/src/views/todo/todo-create-form/TodoCreateForm.tsx
+++ b/src/views/todo/todo-create-form/TodoCreateForm.tsx
@@ -9,7 +9,7 @@ import { TodoForm } from "../TodoForm";
 export default function TodoCreateForm({ goalId }: { goalId?: number }) {
   const { addToast } = useToast();
   const { closeModal } = useModalContext();
-  const todoformProps = useTodoForm(false, undefined, goalId);
+  const todoformProps = useTodoForm({ goalId });
   const { reset } = todoformProps.formMethods;
 
   const createTodoMutation = useCreateTodo();

--- a/src/views/todo/todo-update-form/TodoUpdateForm.tsx
+++ b/src/views/todo/todo-update-form/TodoUpdateForm.tsx
@@ -19,7 +19,10 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
     enabled: !!todoId,
   });
 
-  const todoformProps = useTodoForm(true, todo);
+  const todoformProps = useTodoForm({
+    isUpdate: true,
+    todo,
+  });
 
   const updateTodoSubmit = (data: UpdateTodoBodyDto) => {
     updateTodoMutation.mutate(

--- a/src/views/todo/todo-update-form/TodoUpdateForm.tsx
+++ b/src/views/todo/todo-update-form/TodoUpdateForm.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
 
 import { todoApi } from "@/apis/todoApi";
 import { useModalContext } from "@/contexts/InputModalContext";
@@ -14,36 +13,13 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
   const { addToast } = useToast();
   const { closeModal } = useModalContext();
   const updateTodoMutation = useUpdateTodo();
-
   const { data: todo } = useQuery({
     queryKey: ["todo", todoId],
     queryFn: () => todoApi.fetchTodo(todoId),
     enabled: !!todoId,
   });
 
-  const todoformProps = useTodoForm(true);
-  const { reset, setValue } = todoformProps.formMethods;
-  const { setIsDone, setIsFileCheck, setIsLinkCheck, setSelectedInput } =
-    todoformProps;
-
-  const isInitialized = useRef(false);
-
-  useEffect(() => {
-    if (todo && !isInitialized.current) {
-      reset(todo);
-      setIsDone(todo.done || false);
-
-      if (todo.fileUrl) setValue("fileUrl", todo.fileUrl);
-      setIsFileCheck(!!todo.fileUrl);
-
-      if (todo.linkUrl) setSelectedInput("link");
-      setIsLinkCheck(!!todo.linkUrl);
-
-      if (todo.goal?.id) setValue("goalId", todo.goal.id);
-
-      isInitialized.current = true;
-    }
-  }, [todo]);
+  const todoformProps = useTodoForm(true, todo);
 
   const updateTodoSubmit = (data: UpdateTodoBodyDto) => {
     updateTodoMutation.mutate(
@@ -54,7 +30,7 @@ export default function TodoUpdateForm({ todoId }: { todoId: number }) {
           addToast({
             content: "할 일이 수정되었습니다.",
           });
-          reset();
+          todoformProps.formMethods.reset();
         },
       },
     );


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-213)
  
<br/>

## 📗 작업 내용

- 자식 컴포넌트에서 id를 받아오느라 목표 상세에 상태가 하나 추가되었습니다. 
- 기존 목표값 세팅하면서 변경되는 폼 파일과 훅 수정하면서 리팩토링도 조금씩 해봤습니다.
 (코드리뷰 받은 상태처리/UI폼 로직 분리건, fileApi 클래스로 캡슐화)

<br/>


## 💬 리뷰 요구사항(선택)

- 목표 상세에 코드가 복잡해졌습니다.. 할일 모달 관련 로직 리팩토링.. 예정~.~


