### PR TITLE
refactor(TODO-231): [useInfiniteGoals] 필요한 파트마다 쿼리키 개별적으로 관리하도록 수정

### DIFF
--- a/src/apis/goalApi.ts
+++ b/src/apis/goalApi.ts
@@ -13,11 +13,12 @@ const goalApi = {
    */
   fetchGoals: async (
     pageParam: number | undefined,
+    size: number,
   ): Promise<TeamIdGoalsGet200Response> => {
     const params: teamIdGoalsGetParams = {
       sortOrder: "newest",
-      size: 50,
       cursor: pageParam,
+      size,
     };
     return (await instance.get("/goals", { params })).data;
   },

--- a/src/hooks/goal/useInfiniteGoals.ts
+++ b/src/hooks/goal/useInfiniteGoals.ts
@@ -1,11 +1,14 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 
-import instance from "@/apis/apiClient";
 import goalApi from "@/apis/goalApi";
-import { todoApi } from "@/apis/todoApi";
-import { TeamIdGoalsGet200Response, teamIdGoalsGetParams } from "@/types/types";
+import { TeamIdGoalsGet200Response } from "@/types/types";
 
-export const useInfiniteGoals = () => {
+interface UseInfiniteGoalsParams {
+  source: "sidebar" | "dashboard" | "todoForm";
+  size: number;
+}
+
+export const useInfiniteGoals = ({ source, size }: UseInfiniteGoalsParams) => {
   return useInfiniteQuery<
     TeamIdGoalsGet200Response,
     Error,
@@ -13,9 +16,9 @@ export const useInfiniteGoals = () => {
       goals: TeamIdGoalsGet200Response["goals"];
     }
   >({
-    queryKey: ["goals"],
+    queryKey: ["goals", source],
     queryFn: async ({ pageParam }) =>
-      await goalApi.fetchGoals(pageParam as number | undefined),
+      await goalApi.fetchGoals(pageParam as number | undefined, size),
     initialPageParam: null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     select: (originData) => ({

--- a/src/hooks/goal/useSidebarInfiniteGoals.ts
+++ b/src/hooks/goal/useSidebarInfiniteGoals.ts
@@ -7,7 +7,7 @@ export default function useSidebarInfiniteGoals<
   T extends HTMLElement | null,
   U extends HTMLElement | null,
 >(parentRef: Ref<T>, childRef: Ref<U>) {
-  const query = useInfiniteGoals();
+  const query = useInfiniteGoals({ size: 20, source: "sidebar" });
 
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
 

--- a/src/views/todo/TodoForm.tsx
+++ b/src/views/todo/TodoForm.tsx
@@ -48,7 +48,7 @@ export function TodoForm({
   handleTodoSubmit,
   onSubmit,
 }: TodoFormProps) {
-  const fetchGoalList = useInfiniteGoals();
+  const fetchGoalList = useInfiniteGoals({ size: 50, source: "todoForm" });
   const goals = fetchGoalList.data?.goals || [];
 
   const { register, handleSubmit, watch, control } = formMethods;


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-231)
  
<br/>

## 📗 작업 내용

- 무한 스크롤에서 쿼리 키가 겹쳐 데이터 크기 및 `fetchNextPage`에서 버그가 발생하는 문제를 해결하기 위해, 쿼리 키를 개별적으로 관리하도록 수정하였습니다.  

- `useInfiniteGoals` 함수 호출 시 `size`와 `source`를 인자로 받을 수 있도록 변경하였습니다.  

- `source`는 `"sidebar"`, `"dashboard"`, `"todoForm"`이며, 각각의 쿼리 키에 추가됩니다.

<br/>



