### PR TITLE
feat(TODO-227): 모바일 사이드바 링크 클릭 시 닫힘 처리 및 SMD 크기부터 열림 고정

### DIFF
--- a/src/views/layouts/sidebar/Sidebar.stories.tsx
+++ b/src/views/layouts/sidebar/Sidebar.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
+
+import { InputModalProvider } from "@/contexts/InputModalContext";
+
 import Sidebar from "./Sidebar";
 
 const meta: Meta<typeof Sidebar> = {
@@ -38,6 +41,11 @@ const meta: Meta<typeof Sidebar> = {
       },
       defaultViewport: "desktop", // ✅ 커스텀 뷰포트 적용
     },
+  },
+  render: () => {
+    <InputModalProvider>
+      <Sidebar />
+    </InputModalProvider>;
   },
 };
 

--- a/src/views/layouts/sidebar/Sidebar.tsx
+++ b/src/views/layouts/sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { usePathname } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { createContext, Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import ErrorFallback from "@/components/molecules/error-fallback/ErrorFallback";
@@ -16,6 +16,8 @@ import SidebarHeader from "./components/SidebarHeader";
 const TABLET_BREAKPOINT = 964;
 const TO_HIDE_PATH = ["/", "/login", "/signup"];
 
+export const SidebarContext = createContext<() => void>(() => {});
+
 export default function Sidebar() {
   const pathname = usePathname();
   const isHidden = TO_HIDE_PATH.includes(pathname);
@@ -25,6 +27,12 @@ export default function Sidebar() {
 
   const handleToggleSidebar = () => {
     setIsOpen((prev) => !prev);
+  };
+
+  const handleCloseSidebarAfterAction = () => {
+    if (window.innerWidth < TABLET_BREAKPOINT) {
+      setIsOpen(false);
+    }
   };
 
   useEffect(() => {
@@ -53,27 +61,29 @@ export default function Sidebar() {
             !isOpen && "hidden sm:flex sm:w-[60px] sm:flex-[0_0_60px]",
           )}
         >
-          <SidebarHeader
-            isOpen={isOpen}
-            onToggleSidebar={handleToggleSidebar}
-          />
-          <div
-            className={cn(
-              "flex min-h-0 flex-col opacity-100 [&>*]:px-3 sm:[&>*]:px-6",
-              !isOpen ? "opacity-0" : "transition-[opacity] delay-[10ms]",
-            )}
-          >
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
-              <Suspense>
-                <Profile />
-              </Suspense>
-            </ErrorBoundary>
-            <InputModalProvider>
-              <MenuDashboard />
-            </InputModalProvider>
-            <MenuGoal />
-          </div>
-          <Toaster className="bottom-[40px] w-auto px-4" />
+          <SidebarContext.Provider value={handleCloseSidebarAfterAction}>
+            <SidebarHeader
+              isOpen={isOpen}
+              onToggleSidebar={handleToggleSidebar}
+            />
+            <div
+              className={cn(
+                "flex min-h-0 flex-col opacity-100 [&>*]:px-3 sm:[&>*]:px-6",
+                !isOpen ? "opacity-0" : "transition-[opacity] delay-[10ms]",
+              )}
+            >
+              <ErrorBoundary FallbackComponent={ErrorFallback}>
+                <Suspense>
+                  <Profile />
+                </Suspense>
+              </ErrorBoundary>
+              <InputModalProvider>
+                <MenuDashboard />
+              </InputModalProvider>
+              <MenuGoal />
+            </div>
+            <Toaster className="bottom-[40px] w-auto px-4" />
+          </SidebarContext.Provider>
         </aside>
         <div
           className={cn(

--- a/src/views/layouts/sidebar/Sidebar.tsx
+++ b/src/views/layouts/sidebar/Sidebar.tsx
@@ -55,7 +55,7 @@ export default function Sidebar() {
         <aside
           className={cn(
             // mobile 스타일
-            "fixed inset-0 z-20 box-border flex h-screen w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex,width] ease-[cubic-bezier(0,0.36,0,0.84)]",
+            "fixed inset-0 z-20 box-border flex h-dvh w-full flex-[0_0_100%] flex-col overflow-hidden border-slate-200 bg-white pt-3 pb-8 transition-[flex,width] ease-[cubic-bezier(0,0.36,0,0.84)]",
             // tablet + pc 스타일
             "sm:right-auto sm:w-[280px] sm:flex-[0_0_280px] sm:border-r sm:pb-9",
             !isOpen && "hidden sm:flex sm:w-[60px] sm:flex-[0_0_60px]",

--- a/src/views/layouts/sidebar/Sidebar.tsx
+++ b/src/views/layouts/sidebar/Sidebar.tsx
@@ -5,7 +5,6 @@ import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/molecules/error-fallback/ErrorFallback";
 import Toaster from "@/components/organisms/toaster/Toaster";
 import ToastProvider from "@/components/organisms/toaster/ToastProvider";
-import { InputModalProvider } from "@/contexts/InputModalContext";
 import { cn } from "@/utils/cn";
 import MenuDashboard from "@/views/layouts/sidebar/components/MenuDashBoard";
 import Profile from "@/views/layouts/sidebar/components/Profile";

--- a/src/views/layouts/sidebar/Sidebar.tsx
+++ b/src/views/layouts/sidebar/Sidebar.tsx
@@ -77,9 +77,7 @@ export default function Sidebar() {
                   <Profile />
                 </Suspense>
               </ErrorBoundary>
-              <InputModalProvider>
-                <MenuDashboard />
-              </InputModalProvider>
+              <MenuDashboard />
               <MenuGoal />
             </div>
             <Toaster className="bottom-[40px] w-auto px-4" />

--- a/src/views/layouts/sidebar/components/CloseSidebarLink.tsx
+++ b/src/views/layouts/sidebar/components/CloseSidebarLink.tsx
@@ -1,0 +1,18 @@
+import Link, { LinkProps } from "next/link";
+import { AnchorHTMLAttributes, useContext } from "react";
+
+import { SidebarContext } from "../Sidebar";
+
+export default function CloseSidebarLink({
+  href,
+  children,
+  ...props
+}: LinkProps & AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const handleCloseSidebar = useContext(SidebarContext);
+
+  return (
+    <Link href={href} {...props} onClick={handleCloseSidebar}>
+      {children}
+    </Link>
+  );
+}

--- a/src/views/layouts/sidebar/components/MenuDashBoard.tsx
+++ b/src/views/layouts/sidebar/components/MenuDashBoard.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { memo } from "react";
 
 import { useModalContext } from "@/contexts/InputModalContext";
@@ -6,6 +5,7 @@ import TodoCreateForm from "@/views/todo/todo-create-form/TodoCreateForm";
 
 import AddButton from "./AddButton";
 import MenuItem from "./MenuItem";
+import CloseSidebarLink from "./CloseSidebarLink";
 
 export default memo(function MenuDashboard() {
   const { openModal } = useModalContext();
@@ -16,9 +16,9 @@ export default memo(function MenuDashboard() {
         <AddButton onClick={() => openModal("createTodo")}>새 할일</AddButton>
       </div>
       <section className="flex h-[36px] items-center justify-between border-t border-b border-slate-200 py-3">
-        <Link href="/dashboard">
+        <CloseSidebarLink href="/dashboard">
           <MenuItem title="대시보드" iconSrc="/icons/home.png" />
-        </Link>
+        </CloseSidebarLink>
         <AddButton size="xs" onClick={() => openModal("createTodo")}>
           새 할일
         </AddButton>

--- a/src/views/layouts/sidebar/components/SidebarHeader.tsx
+++ b/src/views/layouts/sidebar/components/SidebarHeader.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
-import Link from "next/link";
-
 import { cn } from "@/utils/cn";
+
+import CloseSidebarLink from "./CloseSidebarLink";
 
 interface SidebarHeaderProps {
   isOpen: boolean;
@@ -19,7 +18,7 @@ export default function SidebarHeader({
         !isOpen && "flex-col gap-4 px-[14px] pt-2",
       )}
     >
-      <Link href="/">
+      <CloseSidebarLink href="/">
         <img
           src="/icons/logo-horizontal.png"
           alt="로고_horizontal"
@@ -34,14 +33,17 @@ export default function SidebarHeader({
           height={32}
           className={cn("hidden", !isOpen && "block h-[32px] w-[32px]")}
         />
-      </Link>
-      <button onClick={onToggleSidebar}>
+      </CloseSidebarLink>
+      <button
+        onClick={onToggleSidebar}
+        className={cn("smd:hidden", !isOpen && "smd:block")}
+      >
         <img
           src="/icons/fold.png"
           width={24}
           height={24}
           alt={isOpen ? "사이드바 닫기" : "사이드바 열기"}
-          className={cn("cursor-pointer", !isOpen && "scale-[-1]")}
+          className={cn(!isOpen && "scale-[-1]")}
         />
       </button>
     </div>

--- a/src/views/layouts/sidebar/components/goals/TabSideMenuItem.tsx
+++ b/src/views/layouts/sidebar/components/goals/TabSideMenuItem.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import CloseSidebarLink from "../CloseSidebarLink";
 
 interface TabSideMenuItemProps {
   content: string;
@@ -11,7 +11,7 @@ export default function TabSideMenuItem({
 }: TabSideMenuItemProps) {
   return (
     <li className="group mr-1 rounded-lg bg-white text-sm font-medium hover:bg-blue-100">
-      <Link
+      <CloseSidebarLink
         href={`/goal/${goalId}`}
         className="box-border flex w-full items-center justify-between gap-2 p-2"
       >
@@ -19,7 +19,7 @@ export default function TabSideMenuItem({
           <span>•</span>
           <span className="break-all">{content}</span>
         </div>
-      </Link>
+      </CloseSidebarLink>
     </li>
   );
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-227)
  
<br/>

## 📗 작업 내용

- 사이드바를 통해 링크 이동 시, 사이드바가 닫히도록 처리했습니다.
- SMD 크기부터 열림 고정 처리

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


