### PR TITLE
feat(TODO-209): 대시보드 진행상황 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-hook-form": "^7.54.2",
     "react-intersection-observer": "^9.15.1",
     "react-quill-new": "^3.3.3",
+    "svg-gauge": "^1.0.7",
     "tailwind-merge": "^3.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-quill-new:
         specifier: ^3.3.3
         version: 3.3.3(quill-delta@5.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      svg-gauge:
+        specifier: ^1.0.7
+        version: 1.0.7
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.0.1
@@ -5222,6 +5225,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-gauge@1.0.7:
+    resolution: {integrity: sha512-k+tG+e6kmTvO80FFS595XzKKF6b6T2KCr5ruzfQ9udl7h72Psl18QElgBrR7ezQd7aZROBNSN7WIle/CyJVCPA==}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -9029,7 +9035,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9051,7 +9057,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@2.4.2)))(eslint@9.19.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.23.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11591,6 +11597,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-gauge@1.0.7: {}
 
   symbol-tree@3.2.4: {}
 

--- a/src/hooks/todo/useProgressTodo.ts
+++ b/src/hooks/todo/useProgressTodo.ts
@@ -2,12 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 
 import instance from "@/apis/apiClient";
 
-async function fetchTodoProgress(goalId: number) {
-  const res = await instance.get(`/todos/progress?goalId=${goalId}`);
+async function fetchTodoProgress(goalId?: number) {
+  const res = await instance.get(`/todos/progress?goalId=${goalId ?? ""}`);
   return res.data;
 }
 
-export default function useProgressTodo(goalId: number) {
+export default function useProgressTodo(goalId?: number) {
   return useQuery({
     queryKey: ["todos", "progress", goalId],
     queryFn: () => fetchTodoProgress(goalId),

--- a/src/styles/gauge.css
+++ b/src/styles/gauge.css
@@ -1,0 +1,13 @@
+@layer components {
+  .custom-gauge .dial {
+    stroke-width: 10px;
+  }
+
+  .custom-gauge .value {
+    stroke-width: 12px;
+  }
+
+  .custom-gauge text {
+    @apply fill-current font-semibold text-black;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,6 +4,7 @@
 @import "./modal.css";
 @import "./slideUp.css";
 @import "./skeleton.css";
+@import "./gauge.css";
 
 @theme {
   /* Font */

--- a/src/views/dashboard/my-progress/MyProgress.tsx
+++ b/src/views/dashboard/my-progress/MyProgress.tsx
@@ -1,7 +1,16 @@
+import Image from "next/image";
+import progressImg from "@public/icons/progress.png";
+
+import Gauge from "./components/Gauge";
+
 export default function MyProgress() {
   return (
-    <section className="h-[250px] flex-1 rounded-xl bg-blue-500 text-white transition-shadow duration-300 hover:shadow-2xl">
-      <h2 className="text-lg font-semibold">내 진행 상황</h2>
+    <section className="flex h-[250px] flex-1 rounded-xl bg-blue-500 text-white transition-shadow duration-300 hover:shadow-2xl">
+      <div className="flex-1 pt-[16px] pl-[24px]">
+        <Image src={progressImg} width={40} height={40} alt="progress" />
+        <p className="mt-[16px] font-normal">내 진행 상황</p>
+      </div>
+      <Gauge />
     </section>
   );
 }

--- a/src/views/dashboard/my-progress/components/Gauge.tsx
+++ b/src/views/dashboard/my-progress/components/Gauge.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import SvgGauge, { GaugeInstance, GaugeOptions } from "svg-gauge";
+
+import useProgressTodo from "@/hooks/todo/useProgressTodo";
+
+export default function Gauge() {
+  const { data } = useProgressTodo();
+  const progress = data?.progress ?? 0;
+  const gaugeEl = useRef<HTMLDivElement>(null);
+  const gaugeRef = useRef<GaugeInstance>(null);
+
+  useEffect(() => {
+    if (!gaugeRef.current) {
+      if (!gaugeEl.current) return;
+      const options: GaugeOptions = {
+        color: () => "#000000",
+        showValue: true,
+        gaugeClass: "custom-gauge",
+        label: (value) => Math.round(value) + "%",
+      };
+      gaugeRef.current = SvgGauge(gaugeEl.current, options);
+      gaugeRef.current?.setValue(1);
+    }
+    gaugeRef.current?.setValueAnimated(progress, 1);
+  }, [progress]);
+
+  return (
+    <div className="mt-[16px] flex flex-1 items-center">
+      <div className="h-[166px] w-[166px]">
+        <div ref={gaugeEl}></div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-209)
  

## 📗 작업 내용

- 대시보드 진행상황 추가
<img src="https://github.com/user-attachments/assets/e1ee1501-2c98-4796-970c-f3d8b7537447" width="350" height="200"/>



## 💬 리뷰 요구사항(선택)

- 먼가 배경에 이미지있으면 좋을것 같은데  심심하군요.
![스크린샷 2025-03-10 141546](https://github.com/user-attachments/assets/d4ff25ea-ce5f-4c12-944f-1f67a7738fcc)


- 감사합니다.




