### PR TITLE
chore(TODO-232): [노트모아보기, 목표상세] SMD 사이즈에서 사이드바에 가려지는 문제 해결

### DIFF
--- a/src/components/organisms/note-detail/NoteDetail.tsx
+++ b/src/components/organisms/note-detail/NoteDetail.tsx
@@ -26,7 +26,7 @@ export default function NoteDetail() {
         onClick={(e) => e.stopPropagation()}
         className="box-border flex h-full w-full flex-col gap-4 border-l border-slate-200 bg-white p-4 break-words whitespace-pre-wrap sm:w-[512px] md:w-[800px] md:p-6"
       >
-        <ExitBtn onClick={handleCloseSidebar} />
+        <ExitBtn className="self-end" onClick={handleCloseSidebar} />
 
         {/* 내부 콘텐츠 부분만 Suspense로 감싸기 */}
         <Suspense fallback={<Spinner size={80} />}>

--- a/src/pages/goal/[goalId]/index.tsx
+++ b/src/pages/goal/[goalId]/index.tsx
@@ -16,7 +16,7 @@ export default function GoalDetailPage() {
       <Head>
         <title>{goalId}</title>
       </Head>
-      <div className="box-border h-full bg-slate-100 px-[16px] pt-[64px] sm:pt-[24px] sm:pr-[24px] sm:pl-[84px] md:pl-[360px]">
+      <div className="smd:pl-[360px] box-border h-full bg-slate-100 px-[16px] pt-[64px] sm:pt-[24px] sm:pr-[24px] sm:pl-[84px]">
         <div className="flex max-w-[1200px] flex-col gap-[16px]">
           {/* 목표 */}
           <PageTitle title="목표" isMobileFixed={true} />

--- a/src/pages/goal/[goalId]/notes/index.tsx
+++ b/src/pages/goal/[goalId]/notes/index.tsx
@@ -16,7 +16,7 @@ export default function NotesPage() {
 
   return (
     <div className="min-h-screen bg-slate-100">
-      <div className="flex max-w-[792px] flex-col gap-4 p-4 sm:pl-[84px] md:pl-[360px]">
+      <div className="smd:pl-[360px] flex max-w-[792px] flex-col gap-4 p-4 sm:pl-[84px]">
         <h1 className="text-lg font-semibold text-slate-900">노트 모아보기</h1>
 
         {hasNotes ? (


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-232)
  
<br/>

## 📗 작업 내용

- 노트 모아보기 및 목표 상세 페이지에서 SMD 사이즈일 때 사이드바에 의해 컨텐츠가 가려지는 현상을 수정했습니다.
- 레이아웃을 조정하여 사이드바와 컨텐츠가 정상적으로 표시되도록 개선했습니다.


![pr](https://github.com/user-attachments/assets/ec2f55b1-a8c4-4bfe-b9d5-039f3ff245a5)

