### PR TITLE
chore(TODO-224): [목표상세] 배경 밖으로 컨텐츠 튀어나오는 부분 수정

### DIFF
--- a/src/pages/goal/[goalId]/index.tsx
+++ b/src/pages/goal/[goalId]/index.tsx
@@ -15,7 +15,7 @@ export default function GoalDetailPage() {
     <GoalDetailProvider goalId={goalId}>
       <QuesddoHead title="목표" />
 
-      <div className="smd:pl-[360px] box-border h-full bg-slate-100 px-[16px] pt-[64px] sm:pt-[24px] sm:pr-[24px] sm:pl-[84px]">
+      <div className="smd:pl-[360px] box-border min-h-screen bg-slate-100 px-[16px] py-4 sm:p-[24px] sm:pl-[84px]">
         <div className="flex max-w-[1200px] flex-col gap-[16px]">
           {/* 목표 */}
           <PageTitle title="목표" isMobileFixed={true} />


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-224)
  
<br/>

## 📗 작업 내용

- 목표상세페이지에서 배경 밖으로 컨텐츠가 튀어나오는 레이아웃을 수정하였습니다.

![image](https://github.com/user-attachments/assets/a6ea67ce-2f93-4147-be29-6c7e801d7eeb)


<br/>





