### PR TITLE
style(TODO-248): 대시보드 진행상황 스타일링 1차수정

### DIFF
--- a/src/styles/gauge.css
+++ b/src/styles/gauge.css
@@ -1,13 +1,13 @@
 @layer components {
   .custom-gauge .dial {
-    stroke-width: 10px;
+    stroke-width: 18px;
   }
 
   .custom-gauge .value {
-    stroke-width: 12px;
+    stroke-width: 20px;
   }
 
   .custom-gauge text {
-    @apply fill-current font-semibold text-black;
+    @apply fill-current font-semibold text-white;
   }
 }

--- a/src/views/dashboard/my-progress/MyProgress.tsx
+++ b/src/views/dashboard/my-progress/MyProgress.tsx
@@ -8,7 +8,7 @@ export default function MyProgress() {
     <section className="flex h-[250px] flex-1 rounded-xl bg-blue-500 text-white transition-shadow duration-300 hover:shadow-2xl">
       <div className="flex-1 pt-[16px] pl-[24px]">
         <Image src={progressImg} width={40} height={40} alt="progress" />
-        <p className="mt-[16px] font-normal">내 진행 상황</p>
+        <p className="mt-[16px] text-2xl font-semibold">내 진행 상황</p>
       </div>
       <Gauge />
     </section>

--- a/src/views/dashboard/my-progress/components/Gauge.tsx
+++ b/src/views/dashboard/my-progress/components/Gauge.tsx
@@ -5,7 +5,6 @@ import useProgressTodo from "@/hooks/todo/useProgressTodo";
 
 export default function Gauge() {
   const { data, isLoading } = useProgressTodo();
-  const progress = data?.progress ?? 0;
   const gaugeEl = useRef<HTMLDivElement>(null);
   const gaugeRef = useRef<GaugeInstance>(null);
 
@@ -21,8 +20,8 @@ export default function Gauge() {
       gaugeRef.current = SvgGauge(gaugeEl.current, options);
       gaugeRef.current?.setValue(0);
     }
-    gaugeRef.current?.setValueAnimated(progress, 1);
-  }, [progress]);
+    gaugeRef.current?.setValueAnimated(data.progress, 2);
+  }, [data]);
 
   if (isLoading) return null;
 

--- a/src/views/dashboard/my-progress/components/Gauge.tsx
+++ b/src/views/dashboard/my-progress/components/Gauge.tsx
@@ -4,7 +4,7 @@ import SvgGauge, { GaugeInstance, GaugeOptions } from "svg-gauge";
 import useProgressTodo from "@/hooks/todo/useProgressTodo";
 
 export default function Gauge() {
-  const { data } = useProgressTodo();
+  const { data, isLoading } = useProgressTodo();
   const progress = data?.progress ?? 0;
   const gaugeEl = useRef<HTMLDivElement>(null);
   const gaugeRef = useRef<GaugeInstance>(null);
@@ -19,13 +19,15 @@ export default function Gauge() {
         label: (value) => Math.round(value) + "%",
       };
       gaugeRef.current = SvgGauge(gaugeEl.current, options);
-      gaugeRef.current?.setValue(1);
+      gaugeRef.current?.setValue(0);
     }
     gaugeRef.current?.setValueAnimated(progress, 1);
   }, [progress]);
 
+  if (isLoading) return null;
+
   return (
-    <div className="mt-[16px] flex flex-1 items-center">
+    <div className="mt-[16px] flex flex-1 items-center justify-center">
       <div className="h-[166px] w-[166px]">
         <div ref={gaugeEl}></div>
       </div>


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-248)
  
<br/>

## 📗 작업 내용

- 게이지 굵기를 키웠습니다.
- 레이블의 색 변경
- 타이틀의 크기 변경

![스크린샷 2025-03-12 003908](https://github.com/user-attachments/assets/1c269902-50ee-4e0f-8623-d534a86e950b)


## 💬 리뷰 요구사항(선택)

- 두번째 여백 이미지입니다.

https://github.com/user-attachments/assets/abaad040-a33b-4709-931b-3ca7f132e199




