### PR TITLE
fix(TODO-255): 사이드바 목표 무한 스크롤 오류 처리

### DIFF
--- a/src/views/layouts/sidebar/components/goals/TabSideMenuList.tsx
+++ b/src/views/layouts/sidebar/components/goals/TabSideMenuList.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, memo, useEffect } from "react";
+import { ForwardedRef, forwardRef, Fragment, memo, useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 
 import Spinner from "@/components/atoms/spinner/Spinner";
@@ -49,7 +49,9 @@ export default memo(
                 goalId={goal.id}
               />
             ))}
-            {data?.goals.length > 0 && <li ref={inViewRef}></li>}
+            {hasNextPage && !isFetchingNextPage && (
+              <li className="h-[20px]" ref={inViewRef}></li>
+            )}
           </>
         )}
       </ul>

--- a/src/views/layouts/sidebar/components/goals/TabSideMenuList.tsx
+++ b/src/views/layouts/sidebar/components/goals/TabSideMenuList.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, Fragment, memo, useEffect } from "react";
+import { ForwardedRef, forwardRef, memo, useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 
 import Spinner from "@/components/atoms/spinner/Spinner";


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-255)
  
<br/>

## 📗 작업 내용

- 스크롤 감지 블럭에 height를 지정하여 인지하지 못하는 문제 방지
- inView의 값의 변화로 useEffect의 조건문이 적용되며 한 페이지 이상의 데이터를 가져오는 문제를 
  스크롤 감지 블럭에 조건을 적용하여 해결

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


