### PR TITLE
refactor(TODO-219): 대시보드 - 최근 등록한 할 일 최적화 및 useTodo 매개변수 개선

### DIFF
--- a/src/hooks/todo/useTodos.ts
+++ b/src/hooks/todo/useTodos.ts
@@ -3,11 +3,17 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { todoApi } from "@/apis/todoApi";
 import { FilterType, TodoResponse } from "@/types/todo";
 
-export const useTodos = (
-  goalId?: number,
-  size?: number,
-  filter?: FilterType, // 모든 할 일(todo, done)을 조회하려면 filter를 지정하지 마세요.
-) => {
+export interface UseTodosParams {
+  goalId?: number;
+  size?: number;
+  filter?: FilterType;
+}
+
+export const useTodos = ({
+  goalId,
+  size,
+  filter, // 모든 할 일(todo, done)을 조회하려면 filter를 지정하지 마세요.
+}: UseTodosParams) => {
   return useSuspenseQuery<TodoResponse>({
     queryKey: ["todos", goalId, filter],
     queryFn: () => todoApi.fetchTodos(goalId, size, filter),

--- a/src/views/dashboard/goal-based-todo/components/TodoWrapper.tsx
+++ b/src/views/dashboard/goal-based-todo/components/TodoWrapper.tsx
@@ -28,7 +28,7 @@ export default function TodoWrapper({
 }: TodoWrapperProps) {
   const {
     data: { todos },
-  } = useTodos(goalId, FETCH_SIZE, doneStatus);
+  } = useTodos({ goalId, size: FETCH_SIZE, filter: doneStatus });
 
   const listLabel = doneStatus === "done" ? "Done" : "To do";
 

--- a/src/views/dashboard/recent-todo/RecentTodo.tsx
+++ b/src/views/dashboard/recent-todo/RecentTodo.tsx
@@ -19,7 +19,7 @@ export default function RecentTodo({
   setSelectedTodoId,
   onOpenDeletePopup,
 }: RecentTodoProps) {
-  const { data } = useTodos();
+  const { data } = useTodos({ size: 5 });
   const router = useRouter();
   const handleShowAll = () => {
     router.push("/todo");


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-219)
  
<br/>

## 📗 작업 내용


1. **대시보드 최근 등록한 할 일 목록 최적화**  
   - 기존: 최근 등록한 할 일 목록을 20개 가져옴  
   - 변경: 5개만 가져오도록 개선하여 불필요한 데이터 로드 방지  

<br/>

2. **`useTodo` 매개변수 개선**  
   - 기존: `useTodo` 훅의 매개변수가 3개로 개별 전달됨  
   - 변경: 객체 형태로 받아 가독성과 확장성을 향상  


<br/>




