### PR TITLE
refactor(TODO-192): `fetchNote` API 함수 통합 및 `useFetchNote` 훅 분리

### DIFF
--- a/src/apis/noteApi.ts
+++ b/src/apis/noteApi.ts
@@ -39,16 +39,7 @@ const noteApi = {
 
   fetchNote: async (noteId: number): Promise<TeamIdNotesPost201Response> => {
     const { data } = await instance.get(`/notes/${noteId}`);
-
     return data;
-  },
-
-  fetchNoteDetail: async (
-    noteId: number,
-  ): Promise<TeamIdNotesGet200ResponseNotesInner | null> => {
-    if (noteId == null) return Promise.resolve(null);
-
-    return (await instance.get(`/notes/${noteId}`)).data;
   },
 
   deleteNote: async (noteId: number) => {

--- a/src/hooks/note/useFetchNote.ts
+++ b/src/hooks/note/useFetchNote.ts
@@ -1,0 +1,10 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import noteApi from "@/apis/noteApi";
+
+export const useFetchNote = (noteId: number) => {
+  return useSuspenseQuery({
+    queryKey: ["noteDetail", noteId],
+    queryFn: () => noteApi.fetchNote(noteId),
+  });
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,10 +22,10 @@ export default function App({ Component, pageProps }: AppProps) {
           <InputModalProvider>
             <div className="flex h-screen flex-col overflow-y-hidden sm:flex-row">
               <Sidebar />
-              <NoteDetail />
 
               <main className="flex-1 overflow-y-auto">
                 <Component {...pageProps} />
+                <NoteDetail />
                 <NoteDrawer />
                 <Toaster />
               </main>

--- a/src/views/note/note-detail/components/EmbeddedContent.tsx
+++ b/src/views/note/note-detail/components/EmbeddedContent.tsx
@@ -1,5 +1,5 @@
 interface EmbeddedContentProps {
-  linkUrl?: string;
+  linkUrl?: string | null;
   isOpen: boolean;
 }
 

--- a/src/views/note/note-detail/components/LinkItem.tsx
+++ b/src/views/note/note-detail/components/LinkItem.tsx
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from "react";
 
 interface LinkItemProps {
   setIsEmbedOpen: Dispatch<SetStateAction<boolean>>;
-  linkUrl?: string;
+  linkUrl?: string | null;
 }
 
 export default function LinkItem({ linkUrl, setIsEmbedOpen }: LinkItemProps) {

--- a/src/views/note/note-detail/components/NoteDetailContent.tsx
+++ b/src/views/note/note-detail/components/NoteDetailContent.tsx
@@ -1,10 +1,9 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
-import noteApi from "@/apis/noteApi";
 import Divider from "@/components/atoms/divider/Divider";
 import GoalItem from "@/components/atoms/goal-item/GoalItem";
 import TodoChip from "@/components/atoms/todo-chip/TodoChip";
+import { useFetchNote } from "@/hooks/note/useFetchNote";
 import { formatDate } from "@/utils/formatDate/formatDate";
 import ReactQuillEditor from "@/views/note/editor/ReactQuillEditor";
 
@@ -17,10 +16,8 @@ interface NoteDetailContentProps {
 export default function NoteDetailContent({ noteId }: NoteDetailContentProps) {
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
 
-  const { data } = useSuspenseQuery({
-    queryKey: ["noteDetail", noteId],
-    queryFn: () => noteApi.fetchNoteDetail(noteId),
-  });
+  const { data } = useFetchNote(noteId);
+
   return (
     <>
       {/* 링크 embed 영역 (링크가 존재할 경우만 표시) */}

--- a/src/views/note/note-form/NoteUpdateForm.tsx
+++ b/src/views/note/note-form/NoteUpdateForm.tsx
@@ -1,9 +1,8 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
 import { useRouter } from "next/router";
 import { useForm } from "react-hook-form";
 
-import noteApi from "@/apis/noteApi";
+import { useFetchNote } from "@/hooks/note/useFetchNote";
 import { useNoteStorage } from "@/hooks/note/useNoteStorage";
 import { useUpdateNote } from "@/hooks/note/useUpdateNote";
 import { UpdateNoteBodyDto } from "@/types/types";
@@ -19,10 +18,7 @@ export default function NoteUpdateForm({ noteId }: NoteUpdateFormProps) {
   const pathname = usePathname();
   const router = useRouter();
 
-  const { data } = useSuspenseQuery({
-    queryKey: ["noteDetail", noteId],
-    queryFn: () => noteApi.fetchNote(noteId),
-  });
+  const { data } = useFetchNote(noteId);
 
   const methods = useForm<UpdateNoteBodyDto>({
     defaultValues: {


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-192)
  
<br/>

## 📗 작업 내용

1. **API 호출 함수 통합**  
   - 기존: 기능이 겹치는 `fetchNote`와 `fetchNoteDetail` 두 개의 API 호출 함수 존재  
   - 변경: `fetchNote` 하나로 통합하여 중복 제거 및 코드 간소화  

<br/>

2. **`fetchNote` 로직 훅으로 분리**  
   - 기존: `fetchNote` 관련 로직이 컴포넌트 내부에 분산되어 있음  
   - 변경: `useFetchNote` 훅으로 분리하여 코드 재사용성을 높임

<br/>




