### PR TITLE
fix(TODO-258): 할일폼 목표드롭다운 무한스크롤 제거

### DIFF
--- a/src/components/organisms/modal/InputModal.tsx
+++ b/src/components/organisms/modal/InputModal.tsx
@@ -237,18 +237,12 @@ function DropdownInput<T extends FieldValues>({
   buttonText,
   name,
   control,
-  fetchNextPage,
-  hasNextPage,
-  isFetchingNextPage,
   ...props
 }: {
   dropdownItems: { title: string; id: number }[];
   buttonText: string;
   name: Path<T>;
   control: Control<T>;
-  fetchNextPage: () => void;
-  hasNextPage: boolean;
-  isFetchingNextPage: boolean;
 }) {
   const {
     field: { onChange, value },
@@ -262,9 +256,6 @@ function DropdownInput<T extends FieldValues>({
       buttonText={buttonText}
       selectedItem={selectedItem}
       onSelect={(item) => onChange(item.id)}
-      fetchNextPage={fetchNextPage}
-      hasNextPage={hasNextPage}
-      isFetchingNextPage={isFetchingNextPage}
       {...props}
     />
   );

--- a/src/views/todo/input-dropdown/InputDropdown.tsx
+++ b/src/views/todo/input-dropdown/InputDropdown.tsx
@@ -10,10 +10,6 @@ interface InputDropdownProps {
   dropdownItems: { title: string; id: number }[];
   selectedItem: { title: string; id: number } | null;
   onSelect: (item: { id: number | null }) => void;
-
-  fetchNextPage?: () => void;
-  hasNextPage?: boolean;
-  isFetchingNextPage?: boolean;
 }
 
 export default function InputDropdown({
@@ -21,14 +17,9 @@ export default function InputDropdown({
   dropdownItems,
   selectedItem,
   onSelect,
-  fetchNextPage,
-  hasNextPage,
-  isFetchingNextPage,
 }: InputDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const loadMoreRef = useRef<HTMLDivElement>(null);
 
   const toggleDropdown = () => setIsOpen(!isOpen);
 
@@ -44,32 +35,6 @@ export default function InputDropdown({
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
-
-  // 무한 스크롤 로직
-  useEffect(() => {
-    if (!isOpen || !loadMoreRef.current) return;
-
-    observerRef.current = new IntersectionObserver(
-      (entries) => {
-        if (
-          entries[0].isIntersecting &&
-          hasNextPage &&
-          fetchNextPage &&
-          !isFetchingNextPage
-        ) {
-          fetchNextPage();
-        }
-      },
-      { threshold: 0.1 },
-    );
-    observerRef.current.observe(loadMoreRef.current);
-
-    return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-      }
-    };
-  }, [isOpen, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <div
@@ -116,9 +81,9 @@ export default function InputDropdown({
               >
                 {buttonText}
               </InputDropdownItem>
-              {dropdownItems.map((item, index) => (
+              {dropdownItems.map((item) => (
                 <InputDropdownItem
-                  key={index}
+                  key={item.id}
                   onClick={() => {
                     onSelect(item);
                     setIsOpen(false);
@@ -127,12 +92,6 @@ export default function InputDropdown({
                   {item.title}
                 </InputDropdownItem>
               ))}
-              {hasNextPage && (
-                <div
-                  ref={loadMoreRef}
-                  className="py-2 text-center text-slate-500"
-                />
-              )}
             </ul>
           </motion.div>
         )}

--- a/src/views/todo/input-dropdown/InputDropdown.tsx
+++ b/src/views/todo/input-dropdown/InputDropdown.tsx
@@ -36,6 +36,11 @@ export default function InputDropdown({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  const handleSelect = (item: { id: number } | null) => {
+    onSelect(item ? item : { id: null });
+    setIsOpen(false);
+  };
+
   return (
     <div
       className="relative w-full text-sm font-normal sm:text-base"
@@ -73,21 +78,14 @@ export default function InputDropdown({
             className="dropdown-scroll absolute z-50 mt-[1px] max-h-[calc(100vh-600px)] min-h-[130px] w-full overflow-hidden overflow-y-auto rounded-xl border border-slate-200 font-semibold shadow-lg sm:max-h-[calc(50vh-270px)]"
           >
             <ul>
-              <InputDropdownItem
-                onClick={() => {
-                  onSelect({ id: null });
-                  setIsOpen(false);
-                }}
-              >
+              <InputDropdownItem onClick={() => handleSelect(null)}>
                 {buttonText}
               </InputDropdownItem>
               {dropdownItems.map((item) => (
                 <InputDropdownItem
                   key={item.id}
-                  onClick={() => {
-                    onSelect(item);
-                    setIsOpen(false);
-                  }}
+                  onClick={() => handleSelect(item)}
+                  selected={selectedItem?.id === item.id}
                 >
                   {item.title}
                 </InputDropdownItem>

--- a/src/views/todo/input-dropdown/InputDropdownItem.tsx
+++ b/src/views/todo/input-dropdown/InputDropdownItem.tsx
@@ -3,18 +3,21 @@ import { cn } from "@/utils/cn/cn";
 interface InputDropdownItemProps {
   children: string;
   onClick?: () => void;
+  selected?: boolean;
 }
 
 export default function InputDropdownItem({
   children,
   onClick,
+  selected,
 }: InputDropdownItemProps) {
   return (
     <li
       onClick={onClick}
       className={cn(
-        "cursor-pointer bg-[#F9FAFB] px-4 py-[10px] font-normal text-slate-800 transition-all duration-200",
+        "cursor-pointer bg-[#F9FAFB] px-4 py-[10px] font-normal text-slate-700 transition-all duration-200",
         "first:text-slate-400 hover:bg-[#E5E7EB] active:bg-blue-50",
+        selected && "bg-blue-100 font-medium",
       )}
     >
       {children}

--- a/src/views/todo/todo-form/TodoForm.tsx
+++ b/src/views/todo/todo-form/TodoForm.tsx
@@ -48,8 +48,7 @@ export function TodoForm({
   handleTodoSubmit,
   onSubmit,
 }: TodoFormProps) {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteGoals({ size: 10, source: "todoForm" });
+  const { data } = useInfiniteGoals({ size: 100, source: "todoForm" });
   const goals = data?.goals || [];
 
   const {
@@ -157,9 +156,6 @@ export function TodoForm({
                 control={control}
                 dropdownItems={goals}
                 buttonText={"목표를 선택해주세요"}
-                fetchNextPage={fetchNextPage}
-                hasNextPage={hasNextPage}
-                isFetchingNextPage={isFetchingNextPage}
               ></InputModal.DropdownInput>
             </div>
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-258)
  
<br/>

## 📗 작업 내용

- 기존 목표가 첫페이지에 없을 때 스크롤을 내려서 불러오고 나서야 해당 값이 뜨게 돼서 무한스크롤 제거하려고 합니다.
![제목 없는 동영상 ](https://github.com/user-attachments/assets/9a63bfbd-f620-4fca-a1d7-584d05f9a93e)
- 선택된 항목 표시
![퀘스또 _ 목표 - Chrome 2025-03-13 오전 9_43_28](https://github.com/user-attachments/assets/d25de089-6a51-43ba-baeb-ca616ac98b44)

<br/>


## 💬 리뷰 요구사항(선택)

- 목표값 설정을 아예 다른 방식으로 하는 수 말곤 모르겠네요🤔 받아오는 데이터와는 무관하게 보여주기?


