### PR TITLE
style(TODO-263): [할일 목록페이지] 스피너 위치 조정 및 스토리북 부활

### DIFF
--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -37,7 +37,7 @@ export default function TodoPage() {
           </button>
         </div>
 
-        <div className="mb-4 h-full rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
+        <div className="mb-4 h-full flex-grow rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
           <BoundaryWrapper>
             <Todos
               handleToggleTodo={handleToggleTodo}

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -37,12 +37,14 @@ export default function TodoPage() {
           </button>
         </div>
 
-        <BoundaryWrapper>
-          <Todos
-            handleToggleTodo={handleToggleTodo}
-            onOpenDeletePopup={onOpenDeletePopup}
-          />
-        </BoundaryWrapper>
+        <div className="mb-4 h-full rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
+          <BoundaryWrapper>
+            <Todos
+              handleToggleTodo={handleToggleTodo}
+              onOpenDeletePopup={onOpenDeletePopup}
+            />
+          </BoundaryWrapper>
+        </div>
       </div>
     </>
   );

--- a/src/pages/todo/index.tsx
+++ b/src/pages/todo/index.tsx
@@ -37,7 +37,7 @@ export default function TodoPage() {
           </button>
         </div>
 
-        <div className="mb-4 h-full flex-grow rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
+        <div className="mb-4 flex-grow rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
           <BoundaryWrapper>
             <Todos
               handleToggleTodo={handleToggleTodo}

--- a/src/views/dashboard/goal-based-todo/GoalBasedTodo.tsx
+++ b/src/views/dashboard/goal-based-todo/GoalBasedTodo.tsx
@@ -27,7 +27,7 @@ export default function GoalBasedTodo() {
   const goals = data ? data.goals : [];
 
   return (
-    <section className="rounded-xl bg-white p-6 transition-shadow duration-300 hover:shadow-2xl">
+    <section className="rounded-xl bg-white p-4 transition-shadow duration-300 hover:shadow-2xl sm:px-6">
       {/* 목표별 할 일 타이틀 */}
       <TitleWithIcon
         title="목표별 할 일"

--- a/src/views/dashboard/my-progress/MyProgress.tsx
+++ b/src/views/dashboard/my-progress/MyProgress.tsx
@@ -5,8 +5,8 @@ import Gauge from "./components/Gauge";
 
 export default function MyProgress() {
   return (
-    <section className="flex h-[250px] flex-1 rounded-xl bg-blue-500 text-white transition-shadow duration-300 hover:shadow-2xl">
-      <div className="flex-1 pt-[16px] pl-[24px]">
+    <section className="flex h-[218px] flex-1 rounded-xl bg-blue-500 p-4 text-white transition-shadow duration-300 hover:shadow-2xl sm:px-6">
+      <div className="flex-1">
         <Image src={progressImg} width={40} height={40} alt="progress" />
         <p className="mt-[16px] text-2xl font-semibold">내 진행 상황</p>
       </div>

--- a/src/views/dashboard/recent-todo/RecentTodo.tsx
+++ b/src/views/dashboard/recent-todo/RecentTodo.tsx
@@ -22,7 +22,7 @@ export default function RecentTodo() {
   const { handleToggleTodo, onOpenDeletePopup } = useTodoListActionContext();
 
   return (
-    <section className="mb-4 h-[218px] flex-1 rounded-xl bg-white p-4 transition-shadow duration-300 hover:shadow-2xl">
+    <section className="mb-4 h-[218px] flex-1 rounded-xl bg-white p-4 transition-shadow duration-300 hover:shadow-2xl sm:px-6">
       <div className="mb-4 flex justify-between">
         <TitleWithIcon
           imgUrl="/icons/todo-recently.png"

--- a/src/views/todo/todoPage/TodoPage.stories.tsx
+++ b/src/views/todo/todoPage/TodoPage.stories.tsx
@@ -1,0 +1,26 @@
+import { InputModalProvider } from "@/contexts/InputModalContext";
+import { TodoListActionProvider } from "@/contexts/TodoListActionContext";
+import TodoPage from "@/pages/todo";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof TodoPage> = {
+  title: "Pages/todo/TodoPage",
+  component: TodoPage,
+  decorators: [
+    (Story) => (
+      <InputModalProvider>
+        <TodoListActionProvider>
+          <Story />
+        </TodoListActionProvider>
+      </InputModalProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TodoPage>;
+
+export const Default: Story = {
+  render: () => <TodoPage />,
+};

--- a/src/views/todo/todoPage/Todos.tsx
+++ b/src/views/todo/todoPage/Todos.tsx
@@ -40,7 +40,7 @@ export default memo(function Todos({
   }, [inView, hasNextPage, fetchNextPage]);
 
   return (
-    <div className="mb-4 flex h-full flex-grow flex-col rounded-xl bg-white p-4 sm:mb-6 sm:max-w-[588px] sm:p-6 md:max-w-[744px]">
+    <div className="flex h-full flex-grow flex-col">
       <div>
         {FILTER_TYPES.map((type) => (
           <button
@@ -52,7 +52,10 @@ export default memo(function Todos({
             )}
           >
             {type}
-            {filter === type && ` (${filteredTodos.length})`}
+            {filter === type &&
+              (filter === "All"
+                ? ` (${data?.totalCount})`
+                : ` (${filteredTodos.length})`)}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-263)
  
<br/>

## 📗 작업 내용

- 전에 스토리북 빌드오류로 임시제거했던 할일페이지 스토리북 재투입
- 겸사겸사 페이지 UI 조정 (필터버튼 옆 항목개수, 스피너 위치)
- 겸사 대시보드 박스들 padding값 일치

<br/>


## 💬 리뷰 요구사항(선택)



