### PR TITLE
feat(TODO-267): [노트 작성/수정] 임시 저장 및 페이지 이동 예외 처리

### DIFF
--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -30,7 +30,7 @@ export const useAutoSaveNoteDraft = ({
 
   const saveDraftNoteAndShowToast = () => {
     const title = getValues("title");
-    const content = getValues("content");
+    const content = getValues("plainText");
     const linkUrl = getValues("linkUrl");
 
     if (isEmptyNote({ title, content, linkUrl })) {

--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 import { type UseFormReturn } from "react-hook-form";
 
+import { isEmptyNote } from "@/views/note/note-form/utils/checkEmptyNote";
+
 import useToast from "../useToast";
 import { useNoteStorage } from "./useNoteStorage";
 
@@ -11,12 +13,6 @@ interface UseAutoSaveNoteDraftProps {
 }
 
 const TOAST_INTERVAL_TIME = 1000 * 60 * 5;
-
-const isEmptyNote = (items: { [key: string]: string | null | undefined }) => {
-  return Object.values(items).every(
-    (item) => !item || item.trim().length === 0,
-  );
-};
 
 export const useAutoSaveNoteDraft = ({
   id,

--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -1,24 +1,28 @@
 import { useEffect, useRef } from "react";
-import { type UseFormReturn } from "react-hook-form";
+import {
+  type FieldValues,
+  type Path,
+  type UseFormReturn,
+} from "react-hook-form";
 
 import { isEmptyNote } from "@/views/note/note-form/utils/checkEmptyNote";
 
 import useToast from "../useToast";
 import { useNoteStorage } from "./useNoteStorage";
 
-interface UseAutoSaveNoteDraftProps {
+interface UseAutoSaveNoteDraftProps<T extends FieldValues> {
   id: number;
-  methods: UseFormReturn;
+  methods: UseFormReturn<T>;
   isEditMode: boolean;
 }
 
 const TOAST_INTERVAL_TIME = 1000 * 60 * 5;
 
-export const useAutoSaveNoteDraft = ({
+export const useAutoSaveNoteDraft = <T extends FieldValues>({
   id,
   methods,
   isEditMode,
-}: UseAutoSaveNoteDraftProps) => {
+}: UseAutoSaveNoteDraftProps<T>) => {
   const {
     getValues,
     formState: { isDirty },
@@ -29,9 +33,11 @@ export const useAutoSaveNoteDraft = ({
   const toastIntervalRef = useRef<NodeJS.Timeout>(null);
 
   const saveDraftNoteAndShowToast = () => {
-    const title = getValues("title");
-    const plainContent = getValues("plainContent");
-    const linkUrl = getValues("linkUrl");
+    const [title, plainContent, linkUrl] = getValues([
+      "title",
+      "plainContent",
+      "linkUrl",
+    ] as Path<T>[]);
 
     if (isEmptyNote({ title, plainContent, linkUrl })) {
       addToast({

--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -36,7 +36,7 @@ export const useAutoSaveNoteDraft = ({
     if (isEmptyNote({ title, content, linkUrl })) {
       addToast({
         variant: "error",
-        content: "빈 노트는 저장할 수 없습니다.",
+        content: "빈 노트는 저장할 수 없습니다",
       });
 
       return;

--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -30,7 +30,7 @@ export const useAutoSaveNoteDraft = ({
 
   const saveDraftNoteAndShowToast = () => {
     const title = getValues("title");
-    const content = getValues("plainText");
+    const content = getValues("plainContent");
     const linkUrl = getValues("linkUrl");
 
     if (isEmptyNote({ title, content, linkUrl })) {

--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -30,10 +30,10 @@ export const useAutoSaveNoteDraft = ({
 
   const saveDraftNoteAndShowToast = () => {
     const title = getValues("title");
-    const content = getValues("plainContent");
+    const plainContent = getValues("plainContent");
     const linkUrl = getValues("linkUrl");
 
-    if (isEmptyNote({ title, content, linkUrl })) {
+    if (isEmptyNote({ title, plainContent, linkUrl })) {
       addToast({
         variant: "error",
         content: "빈 노트는 저장할 수 없습니다",

--- a/src/hooks/note/useBlockNavigation.ts
+++ b/src/hooks/note/useBlockNavigation.ts
@@ -1,5 +1,5 @@
 import { NextRouter, useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useModalContext } from "@/contexts/InputModalContext";
 
@@ -63,7 +63,7 @@ export const useBlockNavigation = ({
     return () => {
       router.beforePopState(() => true);
     };
-  }, [router]);
+  }, [router, isPageMoveRestricted]);
 
   // 외부 링크 이동
   const handleBeforeUnload = useCallback(

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { PropsWithChildren, useState } from "react";
-import { FormProvider, type Path, type UseFormReturn } from "react-hook-form";
+import { FormProvider, type UseFormReturn } from "react-hook-form";
 
 import Button from "@/components/atoms/button/Button";
 import ExitBtn from "@/components/atoms/exit-btn/ExitBtn";

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -18,6 +18,7 @@ import EditorTextCounter from "./components/EditorTextCounter";
 import GoalTodoDisplay from "./components/GoalTodoDisplay";
 import LinkDisplay from "./components/LinkDisplay";
 import LinkModal from "./components/LinkModal";
+import { isEmptyNote } from "./utils/checkEmptyNote";
 
 interface NoteFormProps extends PropsWithChildren {
   id: number;
@@ -38,6 +39,7 @@ export default function NoteForm({
   const router = useRouter();
 
   const {
+    getValues,
     formState: { isValid, isSubmitSuccessful },
   } = methods;
 
@@ -49,7 +51,13 @@ export default function NoteForm({
 
   const { isPopupOpen, handleCanclePopup, handleConfirmPopup } =
     useBlockNavigation({
-      isPageMoveRestricted: !isSubmitSuccessful,
+      isPageMoveRestricted:
+        !isSubmitSuccessful &&
+        !isEmptyNote({
+          title: getValues("title"),
+          content: getValues("plainText"),
+          linkUrl: getValues("linkUrl"),
+        }),
     });
 
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -55,7 +55,7 @@ export default function NoteForm({
         !isSubmitSuccessful &&
         !isEmptyNote({
           title: getValues("title"),
-          content: getValues("plainText"),
+          content: getValues("plainContent"),
           linkUrl: getValues("linkUrl"),
         }),
     });

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -1,6 +1,12 @@
 import { useRouter } from "next/router";
 import { PropsWithChildren, useState } from "react";
-import { FormProvider, type UseFormReturn } from "react-hook-form";
+import {
+  type FieldValues,
+  FormProvider,
+  type Path,
+  type SubmitHandler,
+  type UseFormReturn,
+} from "react-hook-form";
 
 import Button from "@/components/atoms/button/Button";
 import ExitBtn from "@/components/atoms/exit-btn/ExitBtn";
@@ -8,7 +14,6 @@ import PageTitle from "@/components/atoms/page-title/PageTitle";
 import Popup from "@/components/molecules/popup/Popup";
 import { useAutoSaveNoteDraft } from "@/hooks/note/useAutoSaveNoteDraft";
 import { useBlockNavigation } from "@/hooks/note/useBlockNavigation";
-import { CreateNoteBodyDto, UpdateNoteBodyDto } from "@/types/types";
 import EmbeddedContent from "@/views/note/note-detail/components/EmbeddedContent";
 import DraftNoteReminderToast from "@/views/note/note-form/components/DraftNoteReminderToast";
 import Editor from "@/views/note/note-form/components/Editor";
@@ -20,22 +25,22 @@ import LinkDisplay from "./components/LinkDisplay";
 import LinkModal from "./components/LinkModal";
 import { isEmptyNote } from "./utils/checkEmptyNote";
 
-interface NoteFormProps extends PropsWithChildren {
+interface NoteFormProps<T extends FieldValues> extends PropsWithChildren {
   id: number;
-  methods: UseFormReturn;
+  methods: UseFormReturn<T>;
   editMode?: boolean;
-  onSubmit: (data: CreateNoteBodyDto | UpdateNoteBodyDto) => void;
+  onSubmit: SubmitHandler<T>;
   goal?: string;
   todo?: string;
 }
 
-export default function NoteForm({
+export default function NoteForm<T extends FieldValues>({
   id,
   methods,
   onSubmit,
   editMode = false,
   children,
-}: NoteFormProps) {
+}: NoteFormProps<T>) {
   const router = useRouter();
 
   const {
@@ -53,7 +58,7 @@ export default function NoteForm({
     "title",
     "plainContent",
     "linkUrl",
-  ]);
+  ] as Path<T>[]);
 
   const isNoteDirty = !isEmptyNote({
     title,
@@ -70,7 +75,7 @@ export default function NoteForm({
 
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
 
-  const wacthedLinkUrl = methods.watch("linkUrl")?.toString();
+  const wacthedLinkUrl = methods.watch("linkUrl" as Path<T>)?.toString();
 
   const handleToggleEmbedOpen = () => {
     setIsEmbedOpen((prev) => !prev);

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -49,20 +49,28 @@ export default function NoteForm({
     isEditMode: editMode,
   });
 
+  const [title, plainContent, linkUrl] = getValues([
+    "title",
+    "plainContent",
+    "linkUrl",
+  ]);
+
+  const isNoteDirty = !isEmptyNote({
+    title,
+    plainContent,
+    linkUrl,
+  });
+
   const { isPopupOpen, handleCanclePopup, handleConfirmPopup } =
     useBlockNavigation({
       isPageMoveRestricted:
-        !isSubmitSuccessful &&
-        !isEmptyNote({
-          title: getValues("title"),
-          content: getValues("plainContent"),
-          linkUrl: getValues("linkUrl"),
-        }),
+        // (1. 제출되지 않음 상태) + [(2. 수정 모드) or (3. 빈 노트가 아닌 경우)]
+        !isSubmitSuccessful && (editMode || isNoteDirty),
     });
 
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
 
-  const linkUrl = methods.watch("linkUrl")?.toString();
+  const wacthedLinkUrl = methods.watch("linkUrl")?.toString();
 
   const handleToggleEmbedOpen = () => {
     setIsEmbedOpen((prev) => !prev);
@@ -75,7 +83,7 @@ export default function NoteForm({
           <ExitBtn onClick={router.back} className="self-end" />
 
           {/* 링크 embed 영역 (링크가 존재할 경우만 표시) */}
-          <EmbeddedContent isOpen={isEmbedOpen} linkUrl={linkUrl} />
+          <EmbeddedContent isOpen={isEmbedOpen} linkUrl={wacthedLinkUrl} />
 
           <FormProvider {...methods}>
             <form
@@ -130,7 +138,7 @@ export default function NoteForm({
           isCancelEnabled
         >
           <p>정말 나가시겠어요?</p>
-          <p>작성된 내용이 모두 삭제됩니다.</p>
+          <p>{!editMode ? "작성" : "수정"}된 내용이 모두 삭제됩니다.</p>
         </Popup>
       )}
     </>

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -19,25 +19,22 @@ import GoalTodoDisplay from "./components/GoalTodoDisplay";
 import LinkDisplay from "./components/LinkDisplay";
 import LinkModal from "./components/LinkModal";
 
-interface NoteFormProps<TNoteBody extends CreateNoteBodyDto | UpdateNoteBodyDto>
-  extends PropsWithChildren {
+interface NoteFormProps extends PropsWithChildren {
   id: number;
-  methods: UseFormReturn<TNoteBody>;
+  methods: UseFormReturn;
   editMode?: boolean;
-  onSubmit: (data: TNoteBody) => void;
+  onSubmit: (data: CreateNoteBodyDto | UpdateNoteBodyDto) => void;
   goal?: string;
   todo?: string;
 }
 
-export default function NoteForm<
-  TNoteBody extends CreateNoteBodyDto | UpdateNoteBodyDto,
->({
+export default function NoteForm({
   id,
   methods,
   onSubmit,
   editMode = false,
   children,
-}: NoteFormProps<TNoteBody>) {
+}: NoteFormProps) {
   const router = useRouter();
 
   const {
@@ -57,7 +54,7 @@ export default function NoteForm<
 
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);
 
-  const linkUrl = methods.watch("linkUrl" as Path<TNoteBody>)?.toString();
+  const linkUrl = methods.watch("linkUrl")?.toString();
 
   const handleToggleEmbedOpen = () => {
     setIsEmbedOpen((prev) => !prev);

--- a/src/views/note/note-form/components/Editor.tsx
+++ b/src/views/note/note-form/components/Editor.tsx
@@ -33,9 +33,9 @@ export default function Editor() {
     [],
   );
 
-  const handleChangePlainText = () => {
+  const handleChangePlainContent = () => {
     methods.setValue(
-      "plainText",
+      "plainContent",
       editorRef.current?.getEditor().getText().replace(/\n+$/, ""),
       {
         shouldDirty: false,
@@ -47,7 +47,7 @@ export default function Editor() {
     if (!el) return;
     editorRef.current = el;
 
-    handleChangePlainText();
+    handleChangePlainContent();
   }, []);
 
   return (
@@ -63,14 +63,13 @@ export default function Editor() {
             modules={modules}
             onChange={(value: string) => {
               onChange(value);
-              handleChangePlainText();
+              handleChangePlainContent();
             }}
             value={value}
             placeholder="내용을 입력하세요"
           ></ReactQuillEditor>
         )}
       />
-      <input type="hidden" defaultValue="" onChange={handleChangePlainText} />
     </>
   );
 }

--- a/src/views/note/note-form/components/EditorTextCounter.tsx
+++ b/src/views/note/note-form/components/EditorTextCounter.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from "react-hook-form";
 export default function EditorTextCounter() {
   const { watch } = useFormContext();
 
-  const textLength = watch("plainText");
+  const textLength = watch("plainContent");
   const textWithoutLength = textLength?.replace(/\s/gm, "").length || 0;
 
   return (

--- a/src/views/note/note-form/utils/checkEmptyNote.ts
+++ b/src/views/note/note-form/utils/checkEmptyNote.ts
@@ -1,0 +1,7 @@
+export const isEmptyNote = (items: {
+  [key: string]: string | null | undefined;
+}) => {
+  return Object.values(items).every(
+    (item) => !item || item.trim().length === 0,
+  );
+};


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-267)
  
<br/>

## 📗 작업 내용

- 노트 작성 중 빈 노트인 경우 페이지 이동 모달이 나타나지 않도록 처리했습니다.
- 빈 노트인 경우 임시 저장을 하지 못하도록 처리했습니다.

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


