### PR TITLE
fix(TODO-268): 느린 인터넷 환경에서 로그인 된 사용자가 루트 접속 시 빈화면 보이는 현상 처리

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,4 +1,6 @@
 import PageTitle from "@/components/atoms/page-title/PageTitle";
+import Spinner from "@/components/atoms/spinner/Spinner";
+import BoundaryWrapper from "@/components/organisms/boundary-wrapper/BoundaryWrapper";
 import GoalBasedTodo from "@/views/dashboard/goal-based-todo/GoalBasedTodo";
 import MyProgress from "@/views/dashboard/my-progress/MyProgress";
 import RecentTodo from "@/views/dashboard/recent-todo/RecentTodo";
@@ -14,8 +16,10 @@ export default function Dashboard() {
         <PageTitle title="대시보드" className="sm:pt-6" isMobileFixed={true} />
 
         <div className="smd:max-w-[1200px] smd:gap-5 flex flex-grow flex-col gap-4 py-4 sm:pt-0">
-          <div className="sm:flex sm:h-[250px] sm:justify-between sm:gap-5">
-            <RecentTodo />
+          <div className="sm:flex sm:h-[250px] sm:justify-between sm:gap-5 [&>*]:flex-[1_1_50%]">
+            <BoundaryWrapper fallback={<Spinner size={60} />}>
+              <RecentTodo />
+            </BoundaryWrapper>
             <MyProgress />
           </div>
           <GoalBasedTodo />

--- a/src/views/dashboard/recent-todo/RecentTodo.tsx
+++ b/src/views/dashboard/recent-todo/RecentTodo.tsx
@@ -1,8 +1,6 @@
 import Image from "next/image";
 import { useRouter } from "next/router";
-import { Suspense } from "react";
 
-import Spinner from "@/components/atoms/spinner/Spinner";
 import TitleWithIcon from "@/components/atoms/title-with-icon/TitleWithIcon.tsx";
 import TodoList from "@/components/organisms/todo-list/TodoList";
 import { useTodoListActionContext } from "@/contexts/TodoListActionContext";
@@ -41,13 +39,11 @@ export default function RecentTodo() {
 
       <div className="h-full max-h-[154px] overflow-y-hidden">
         {hasTodos ? (
-          <Suspense fallback={<Spinner size={60} />}>
-            <TodoList
-              data={todos}
-              handleToggleTodo={handleToggleTodo}
-              onOpenDeletePopup={onOpenDeletePopup}
-            />
-          </Suspense>
+          <TodoList
+            data={todos}
+            handleToggleTodo={handleToggleTodo}
+            onOpenDeletePopup={onOpenDeletePopup}
+          />
         ) : (
           <div className="flex h-full items-center justify-center text-sm font-normal text-slate-500">
             최근에 등록한 할 일이 없어요


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-268)
  
<br/>

## 📗 작업 내용

- RecentTodo 부모에서 에러, 로딩 처리
- 기본으로 `가장 최근에 추가한 할 일`, `진행률`이 전체의 50%의 width를 가지도록 스타일 수정

<br/>


## 💬 리뷰 요구사항(선택)

노션에 관련 글 추가했습니다.
- [노션 바로가기](https://www.notion.so/Suspense-1b58a37bf8a2803788eacfeee67a89ea?pvs=4)


