### PR TITLE
fix(TODO-269): 로그인 탭 화면 전환 시 값 사라짐

### DIFF
--- a/src/hooks/user/useFetchUser.ts
+++ b/src/hooks/user/useFetchUser.ts
@@ -14,6 +14,7 @@ export const useFetchUser = (throwOnError = false) => {
     retry: false,
     staleTime: 1000 * 60 * 60,
     throwOnError: throwOnError,
+    refetchOnWindowFocus: false,
   });
 
   return {


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-269) 


## 📗 작업 내용
- 로그인/회원가입 탭 전환 시 값 사라짐 현상 수정

## 💬 리뷰 요구사항(선택)

- 로그인, 회원가입 탭에서 화면 전환 시 refetch로 인한 리렌더링으로 값이 사라집니다
  - 인증 이후에는 값이 캐시되어 문제 없었을 거에요
- refetchOnWindowFocus 옵션으로 작업했으나 프로파일 쪽과 같은 훅을 사용하여 은영님과 협의가 필요할 것 같습니다
