### PR TITLE
style(TODO-273): [노트 모아보기] 카드 hover시 shadow 적용

### DIFF
--- a/src/views/notes/card/Card.tsx
+++ b/src/views/notes/card/Card.tsx
@@ -18,7 +18,7 @@ interface CardHeaderProps {
 
 export default function Card({ children }: PropsWithChildren) {
   return (
-    <div className="relative flex flex-col gap-4 rounded-xl bg-white p-6">
+    <div className="relative flex flex-col gap-4 rounded-xl bg-white p-6 transition hover:shadow-2xl">
       {children}
     </div>
   );

--- a/src/views/notes/card/Card.tsx
+++ b/src/views/notes/card/Card.tsx
@@ -18,7 +18,7 @@ interface CardHeaderProps {
 
 export default function Card({ children }: PropsWithChildren) {
   return (
-    <div className="relative flex flex-col gap-4 rounded-xl bg-white p-6 transition hover:shadow-2xl">
+    <div className="relative flex flex-col gap-4 rounded-xl bg-white p-6 transition hover:shadow">
       {children}
     </div>
   );


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-273)
  
<br/>

## 📗 작업 내용

- 노트모아보기 페이지에 카드 hover 시 shadow 적용하였습니다.

![image](https://github.com/user-attachments/assets/d77c9481-2999-44c5-b615-55269cffa460)


<br/>




