### PR TITLE
style(TODO-277): Toaster 스타일 수정

### DIFF
--- a/src/components/organisms/toaster/Toaster.tsx
+++ b/src/components/organisms/toaster/Toaster.tsx
@@ -15,7 +15,7 @@ export default function Toaster({ className }: ToasterProps) {
   return (
     <div
       className={cn(
-        "pointer-events-none sticky bottom-0 z-50 flex h-0 flex-col-reverse bg-red-200",
+        "pointer-events-none fixed right-0 bottom-0 z-50 flex h-0 flex-col-reverse bg-red-200",
         className,
       )}
     >

--- a/src/views/layouts/sidebar/Sidebar.tsx
+++ b/src/views/layouts/sidebar/Sidebar.tsx
@@ -76,7 +76,7 @@ export default function Sidebar() {
               <MenuDashboard />
               <MenuGoal />
             </div>
-            <Toaster className="bottom-[40px] w-auto px-4" />
+            <Toaster className="absolute bottom-[40px] box-border w-full px-4" />
           </SidebarContext.Provider>
         </aside>
         <div


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-277)
  
<br/>

## 📗 작업 내용

- 모바일에서 Toast가 보이지 않아 아래 작업을 진행했습니다.
  - 전역(_app.tsx)에 있는 Toaster 컴포넌트의 스타일을 sticky에서 fixed로 수정
  - 사이드 바에 있는 Toaster 컴포넌트의 스타일을 sticky에서 absolute로 수정


<br/>


## 💬 리뷰 요구사항(선택)



