### PR TITLE
refactor(TODO-275): [노트 작성] 노트 작성 시도가 있었던 경우 페이지 이동 시 모달 open

### DIFF
--- a/src/hooks/note/useAutoSaveNoteDraft.ts
+++ b/src/hooks/note/useAutoSaveNoteDraft.ts
@@ -5,8 +5,6 @@ import {
   type UseFormReturn,
 } from "react-hook-form";
 
-import { isEmptyNote } from "@/views/note/note-form/utils/checkEmptyNote";
-
 import useToast from "../useToast";
 import { useNoteStorage } from "./useNoteStorage";
 
@@ -17,6 +15,12 @@ interface UseAutoSaveNoteDraftProps<T extends FieldValues> {
 }
 
 const TOAST_INTERVAL_TIME = 1000 * 60 * 5;
+
+const isEmptyNote = (items: { [key: string]: string | null | undefined }) => {
+  return Object.values(items).every(
+    (item) => !item || item.trim().length === 0,
+  );
+};
 
 export const useAutoSaveNoteDraft = <T extends FieldValues>({
   id,

--- a/src/views/note/note-create-form/NoteCreateForm.tsx
+++ b/src/views/note/note-create-form/NoteCreateForm.tsx
@@ -27,6 +27,7 @@ export default function NoteCreateForm({ todoId }: NoteCreationFormProps) {
         title: data?.title,
         done: data?.done,
       },
+      plainContent: "",
     },
     mode: "onChange",
   });

--- a/src/views/note/note-form/NoteForm.tsx
+++ b/src/views/note/note-form/NoteForm.tsx
@@ -23,7 +23,6 @@ import EditorTextCounter from "./components/EditorTextCounter";
 import GoalTodoDisplay from "./components/GoalTodoDisplay";
 import LinkDisplay from "./components/LinkDisplay";
 import LinkModal from "./components/LinkModal";
-import { isEmptyNote } from "./utils/checkEmptyNote";
 
 interface NoteFormProps<T extends FieldValues> extends PropsWithChildren {
   id: number;
@@ -44,8 +43,7 @@ export default function NoteForm<T extends FieldValues>({
   const router = useRouter();
 
   const {
-    getValues,
-    formState: { isValid, isSubmitSuccessful },
+    formState: { isValid, isSubmitSuccessful, isDirty },
   } = methods;
 
   const { handleClickSaveDraft } = useAutoSaveNoteDraft({
@@ -54,23 +52,11 @@ export default function NoteForm<T extends FieldValues>({
     isEditMode: editMode,
   });
 
-  const [title, plainContent, linkUrl] = getValues([
-    "title",
-    "plainContent",
-    "linkUrl",
-  ] as Path<T>[]);
-
-  const isNoteDirty = !isEmptyNote({
-    title,
-    plainContent,
-    linkUrl,
-  });
-
   const { isPopupOpen, handleCanclePopup, handleConfirmPopup } =
     useBlockNavigation({
       isPageMoveRestricted:
-        // (1. 제출되지 않음 상태) + [(2. 수정 모드) or (3. 빈 노트가 아닌 경우)]
-        !isSubmitSuccessful && (editMode || isNoteDirty),
+        // (1. 제출되지 않음 상태) + [(2. 수정 모드) or (3. 글 작성 시도한 경우)]
+        !isSubmitSuccessful && (editMode || isDirty),
     });
 
   const [isEmbedOpen, setIsEmbedOpen] = useState(false);

--- a/src/views/note/note-form/utils/checkEmptyNote.ts
+++ b/src/views/note/note-form/utils/checkEmptyNote.ts
@@ -1,7 +1,0 @@
-export const isEmptyNote = (items: {
-  [key: string]: string | null | undefined;
-}) => {
-  return Object.values(items).every(
-    (item) => !item || item.trim().length === 0,
-  );
-};


### PR DESCRIPTION
## 🔗 연관된 이슈

- [연관된 이슈 링크](https://quesddo.atlassian.net/browse/TODO-275)
  
<br/>

## 📗 작업 내용

- 기존에는 노트 작성 중 페이지 이동 시 빈 노트이면 페이지 이동 모달을 띄우지 않았으나,
- 한 번이라도 입력을 했던 경우에는 페이지 이동 모달을 띄우도록 수정했습니다.

<br/>


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


